### PR TITLE
Fix error message when using depth texture without extension.

### DIFF
--- a/lib/texture.js
+++ b/lib/texture.js
@@ -602,7 +602,7 @@ module.exports = function createTextureSet (
         !(type === 'half float' || type === 'float16'),
         'you must enable the OES_texture_half_float extension in order to use 16-bit floating point textures.')
       check(extensions.webgl_depth_texture ||
-        !(type === 'depth' || type === 'depth stencil'),
+        !(type === 'uint16' || type === 'uint32' || type === 'depth stencil'),
         'you must enable the WEBGL_depth_texture extension in order to use depth/stencil textures.')
       check.parameter(type, textureTypes,
         'invalid texture type')


### PR DESCRIPTION
Fixes so that we are correctly reporting an error if you use the texture types 'uint16', 'uint32', or 'depth stencil' without the 'WEBGL_depth_texture' extension.

This resolves issue #318.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/320)
<!-- Reviewable:end -->
