### PR TITLE
shaderCount now takes the shader cache into account

### DIFF
--- a/lib/shader.js
+++ b/lib/shader.js
@@ -193,8 +193,6 @@ module.exports = function wrapShaderState (gl, stringStore, stats, config) {
       check.command(vertId >= 0, 'missing vertex shader', command)
       check.command(fragId >= 0, 'missing fragment shader', command)
 
-      stats.shaderCount++
-
       var cache = programCache[fragId]
       if (!cache) {
         cache = programCache[fragId] = {}
@@ -202,6 +200,8 @@ module.exports = function wrapShaderState (gl, stringStore, stats, config) {
       var program = cache[vertId]
       if (!program) {
         program = new REGLProgram(fragId, vertId)
+        stats.shaderCount++
+
         linkProgram(program, command)
         cache[vertId] = program
         programList.push(program)

--- a/test/stats.js
+++ b/test/stats.js
@@ -127,6 +127,37 @@ tape('test regl.stats', function (t) {
 
     regl.destroy()
     t.equals(stats.shaderCount, 0, 'stats.shaderCount==0 after regl.destroy()')
+
+    regl = createREGL(gl)
+    stats = regl.stats
+
+    var frag = [
+      'precision mediump float;',
+      'void main () { gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0); } '
+    ].join('\n')
+
+    var vert = [
+      'precision mediump float;',
+      'attribute vec2 position;',
+      'void main () {gl_Position = vec4(position, 0, 1); }'
+    ].join('\n')
+
+    var draw3 = regl({
+      frag: regl.prop('frag'),
+      vert: regl.prop('vert'),
+      attributes: { position: [[-1, 0], [0, -1], [1, 1]] },
+      uniforms: { color: [1, 0, 0, 1] },
+      count: 3
+    })
+
+    for (var i = 0; i < 30; i++) {
+      draw3({frag: frag, vert: vert})
+    }
+
+    t.equals(stats.shaderCount, 1, 'stats.shaderCount==1, after calling dynamic drawCommand several times')
+
+    regl.destroy()
+
     //
     // End Test stats.shaderCount
     //


### PR DESCRIPTION
Fix so that `regl.stats.shaderCount` takes the shader cache into account.

This fixes issue #344.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/348)
<!-- Reviewable:end -->
