### PR TITLE
fix resize of canvas in non-body element

### DIFF
--- a/lib/webgl.js
+++ b/lib/webgl.js
@@ -27,7 +27,7 @@ function createCanvas (element, onDone, pixelRatio) {
     if (element !== document.body) {
       var bounds = element.getBoundingClientRect()
       w = bounds.right - bounds.left
-      h = bounds.top - bounds.bottom
+      h = bounds.bottom - bounds.top
     }
     canvas.width = pixelRatio * w
     canvas.height = pixelRatio * h


### PR DESCRIPTION
Hi – thanks for this project, really excited to start learning it. Just ran into a small problem – if you initialise with a non-canvas, non-body element, resizing fails because the height is calculated as `bounds.top - bounds.bottom` which is negative and therefore invalid.

Wasn't sure where to put a test for this, but if you need one am happy to update the PR if you point me in the right direction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/356)
<!-- Reviewable:end -->
