### PR TITLE
Improve ergonomics around framebuffers

### DIFF
--- a/API.md
+++ b/API.md
@@ -1363,7 +1363,7 @@ var positionBuffer = regl.buffer([
 | `type`   | Data type for vertex buffer                                    | `'uint8'` |
 
 - `usage` can be one of the following values
- 
+
 | Usage Hint  | Description       |
 | ----------- | ----------------- |
 | `'static'`  | `gl.DRAW_STATIC`  |
@@ -1371,16 +1371,16 @@ var positionBuffer = regl.buffer([
 | `'stream'`  | `gl.STREAM_DRAW`  |
 
  - `type` can be one of the following data types
- 
-| Data type          | Description          | 
+
+| Data type          | Description          |
 | ------------------ | ---------------------|
 | `'uint8'`          | `gl.UNSIGNED_BYTE`   |  
 | `'int8'`           | `gl.BYTE`            |  
-| `'uint16'`         | `gl.UNSIGNED_SHORT`  | 
-| `'int16'`          | `gl.SHORT`           | 
-| `'uint32'`         | `gl.UNSIGNED_INT`    | 
-| `'int32'`          | `gl.INT`             | 
-| `'float32'`, `'float'`  | `gl.FLOAT`      | 
+| `'uint16'`         | `gl.UNSIGNED_SHORT`  |
+| `'int16'`          | `gl.SHORT`           |
+| `'uint32'`         | `gl.UNSIGNED_INT`    |
+| `'int32'`          | `gl.INT`             |
+| `'float32'`, `'float'`  | `gl.FLOAT`      |
 
 **Relevant WebGL APIs**
 
@@ -1413,7 +1413,7 @@ The arguments to the update pathway are the same as the constructor and the retu
 
 ##### Buffer subdata
 
-For performance reasons we may sometimes want to update just a portion of the buffer. 
+For performance reasons we may sometimes want to update just a portion of the buffer.
 You can update a portion of the buffer using the `subdata` method.  This can be useful if you are dealing with frequently changing or streaming vertex data.  Here is an example:
 
 ```javascript
@@ -1519,7 +1519,7 @@ var starElements = regl.elements({
 | `'triangle fan'`   | `gl.TRIANGLE_FAN`   |
 
 -   `type` can be one of the following data types
- 
+
 | Data type          | Description          | Extension? |
 | ------------------ | ---------------------|------------|
 | `'uint8'`          | `gl.UNSIGNED_BYTE`   |            |
@@ -2264,6 +2264,29 @@ framebuffer({
 })
 ```
 
+##### Framebuffer binding
+
+For convenience it is possible to bind a framebuffer directly.  This is a short cut for creating a command which sets the framebuffer:
+
+```javascript
+var framebuffer = regl.framebuffer(5)
+
+framebuffer.bind(function () {
+  // now we can draw to the framebuffer
+})
+
+//
+// This is the same as doing the following:
+//
+var setFBO = regl({
+  framebuffer: framebuffer
+})
+
+setFBO(function () {
+  // .. same situation as above
+})
+```
+
 ##### Framebuffer resize
 
 Framebuffers can be resized using the `.resize()` method.  This method will also modify all of the framebuffer's attachments.
@@ -2378,6 +2401,7 @@ regl.clear({
 | `color`   | Sets the clear color         |
 | `depth`   | Sets the clear depth value   |
 | `stencil` | Sets the clear stencil value |
+| `framebuffer` | Sets the target framebuffer to clear (if unspecified, uses the current framebuffer object) |
 
 If an option is not present, then the corresponding buffer is not cleared
 
@@ -2431,6 +2455,7 @@ regl({framebuffer: fbo})(() => {
 | `y`      | The y-offset of the upper-left corner of the rectangle in pixels          | `0`                        |
 | `width`  | The width of the rectangle in pixels                                      | Current framebuffer width  |
 | `height` | The height of the rectangle in pixels                                     | Current framebuffer height |
+| `framebuffer` | Sets the framebuffer to read pixels from | The currently bound framebuffer |
 
 **Notes**
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## Next
+
+* Add `framebuffer.bind()` method for quickly setting up framebuffer objects
+* `regl.clear` and `regl.read` now accept a framebuffer as a parameter
+
 ## 1.2.1
 
 * Fixed bug with depth and stencil attachments being cleared

--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -85,7 +85,8 @@ module.exports = function wrapFBOState (
   var framebufferState = {
     cur: null,
     next: null,
-    dirty: false
+    dirty: false,
+    setFBO: null
   }
 
   var colorTextureFormats = ['rgba']
@@ -675,6 +676,11 @@ module.exports = function wrapFBOState (
       destroy: function () {
         destroy(framebuffer)
         decFBORefs(framebuffer)
+      },
+      bind: function (block) {
+        framebufferState.setFBO({
+          framebuffer: reglFramebuffer
+        }, block)
       }
     })
   }

--- a/lib/read.js
+++ b/lib/read.js
@@ -13,7 +13,7 @@ module.exports = function wrapReadPixels (
   context,
   glAttributes,
   extensions) {
-  function readPixels (input) {
+  function readPixelsImpl (input) {
     var type
     if (framebufferState.next === null) {
       check(
@@ -106,6 +106,24 @@ module.exports = function wrapReadPixels (
                   data)
 
     return data
+  }
+
+  function readPixelsFBO (options) {
+    var result
+    framebufferState.setFBO({
+      framebuffer: options.framebuffer
+    }, function () {
+      result = readPixelsImpl(options)
+    })
+    return result
+  }
+
+  function readPixels (options) {
+    if (!options || !('framebuffer' in options)) {
+      return readPixelsImpl(options)
+    } else {
+      return readPixelsFBO(options)
+    }
   }
 
   return readPixels

--- a/test/clear-fbo.js
+++ b/test/clear-fbo.js
@@ -1,0 +1,58 @@
+'use strict'
+
+var createContext = require('./util/create-context')
+var createREGL = require('../../regl')
+var tape = require('tape')
+
+tape('clear fbo', function (t) {
+  function arrayEq (x, y, m) {
+    t.same(
+      Array.prototype.slice.call(x),
+      Array.prototype.slice.call(y),
+      m)
+  }
+
+  setTimeout(function () {
+    var gl = createContext(1, 1)
+    var regl = createREGL(gl)
+
+    var fbo = regl.framebuffer({
+      shape: [1, 1, 4],
+      colorTexture: true
+    })
+
+    regl.clear({
+      color: [1, 0, 0, 1]
+    })
+
+    regl.clear({
+      framebuffer: fbo,
+      color: [0, 1, 0, 1]
+    })
+
+    arrayEq(regl.read(), [255, 0, 0, 255], 'drawing buffer ok')
+    arrayEq(regl.read({
+      framebuffer: fbo
+    }), [0, 255, 0, 255], 'fbo ok')
+
+    fbo.bind(function () {
+      regl.clear({
+        color: [0, 0, 1, 1]
+      })
+      regl.clear({
+        framebuffer: null,
+        color: [1, 0, 1, 1]
+      })
+
+      arrayEq(regl.read(), [0, 0, 255, 255], 'drawing buffer ok')
+      arrayEq(regl.read({
+        framebuffer: null
+      }), [255, 0, 255, 255], 'fbo ok')
+    })
+
+    regl.destroy()
+    t.equals(gl.getError(), 0, 'error ok')
+    createContext.destroy(gl)
+    t.end()
+  }, 120)
+})


### PR DESCRIPTION
This PR makes the APIs for working with framebuffers a bit more convenient.  It adds the following convenience methods:

* You can now bind framebuffers directly by calling `framebuffer.bind()` and passing in a function.  This saves you from having to write out a separate command for setting the framebuffer.
* `regl.clear` and `regl.read` now accept framebuffers as parameters.  This was a common point of confusion for many beginners who did not realize that you could access the framebuffer using a command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/362)
<!-- Reviewable:end -->
