### PR TITLE
rename framebuffer bind to use to avoid conflict

### DIFF
--- a/API.md
+++ b/API.md
@@ -2279,7 +2279,7 @@ For convenience it is possible to bind a framebuffer directly.  This is a short 
 ```javascript
 var framebuffer = regl.framebuffer(5)
 
-framebuffer.bind(function () {
+framebuffer.use(function () {
   // now we can draw to the framebuffer
 })
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-* Add `framebuffer.bind()` method for quickly setting up framebuffer objects
+* Add `framebuffer.use()` method for quickly setting up framebuffer objects
 * `regl.clear` and `regl.read` now accept a framebuffer as a parameter
 
 ## 1.2.1

--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -677,7 +677,7 @@ module.exports = function wrapFBOState (
         destroy(framebuffer)
         decFBORefs(framebuffer)
       },
-      bind: function (block) {
+      use: function (block) {
         framebufferState.setFBO({
           framebuffer: reglFramebuffer
         }, block)

--- a/test/clear-fbo.js
+++ b/test/clear-fbo.js
@@ -35,7 +35,7 @@ tape('clear fbo', function (t) {
       framebuffer: fbo
     }), [0, 255, 0, 255], 'fbo ok')
 
-    fbo.bind(function () {
+    fbo.use(function () {
       regl.clear({
         color: [0, 0, 1, 1]
       })


### PR DESCRIPTION
As pointed out by @vorg using bind for a property hanging off a function is a pretty bad idea.

This fixes that problem by renaming the new `bind()` helper method to `use()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/366)
<!-- Reviewable:end -->
