### PR TITLE
Fix example cube fbo

### DIFF
--- a/example/cube-fbo.js
+++ b/example/cube-fbo.js
@@ -154,7 +154,7 @@ const drawTeapot = regl({
   varying vec3 eyeDir, fragNormal;
 
   void main () {
-    vec4 env = textureCube(envMap, reflect(eyeDir, fragNormal));
+    vec4 env = textureCube(envMap, reflect(-eyeDir, fragNormal));
     gl_FragColor = vec4(env.rgb * (normalize(fragNormal) + 0.8), 1);
   }`,
 


### PR DESCRIPTION
This pull request fixed two issues with the cubemap framebuffer example:

- In glsl `reflect(I, N)` should take an incident vector that is opposite to the
   eyeDir (so -eyeDir) and a surface normal
   More https://www.opengl.org/sdk/docs/man4/html/reflect.xhtml

- Cubemap was rendered upside down because FBO 0,0 is at the bottom left while for cubemaps 0,0 at the top left. The solution is to flip the UP vector in our lookAt matrix while rendering to the FBO. More here http://www.nvidia.com/object/cube_map_ogl_tutorial.html and here http://www.mbroecker.com/project_dynamic_cubemaps.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/368)
<!-- Reviewable:end -->
