### PR TITLE
Update API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -1815,7 +1815,7 @@ So it can be used as an alternative to `format`.
 | `'none'`    | `gl.NONE`                  |
 | `'browser'` | `gl.BROWSER_DEFAULT_WEBGL` |
 
--   `unpackAlignment` sets the pixel unpack alignment and must be one of `[1, 2, 4, 8]`
+-   `alignment` sets the pixel unpack alignment and must be one of `[1, 2, 4, 8]`
 
 **Relevant WebGL APIs**
 


### PR DESCRIPTION
Documentation for the `texture()` constructors says to use `unpackAlignment` to configure the `GL_UNPACK_ALIGNMENT` value. However, according to https://github.com/regl-project/regl/blob/gh-pages/lib/texture.js#L553 the property `alignment` should be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/380)
<!-- Reviewable:end -->
