### PR TITLE
Add a couple more lines on passing array uniforms

### DIFF
--- a/API.md
+++ b/API.md
@@ -634,6 +634,7 @@ var command = regl({
   uniform vec4 someUniform;
   uniform int anotherUniform;
   uniform SomeStruct nested;
+  uniform vec4 colors[2];
 
   void main() {
     gl_Position = vec4(1, 0, 0, 1);
@@ -642,7 +643,9 @@ var command = regl({
   uniforms: {
     someUniform: [1, 0, 0, 1],
     anotherUniform: regl.prop('myProp'),
-    'nested.value': 5.3
+    'nested.value': 5.3,
+    'colors[0]': [0, 1, 0, 1],
+    'colors[1]': [0, 0, 1, 1]
   },
 
   // ...


### PR DESCRIPTION
The syntax for arrays took me a bit to figure out and I'm still not 100% sure whether or not there's a more compact way (`colors: [[0, 1, 0, 1], [0, 0, 1, 1]]`?) This PR adds another uniform example to help communicate what's possible.

See: http://codepen.io/rsreusser/pen/ENqwoj

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/389)
<!-- Reviewable:end -->
