### PR TITLE
check the main field in the transform comparison

### DIFF
--- a/browserify/transform.js
+++ b/browserify/transform.js
@@ -7,6 +7,8 @@ var fs = require('fs')
 
 var REGL_PATH = path.normalize(path.join(__dirname,
   '../regl.js'))
+var REGL_MAIN_PATH = path.normalize(path.join(__dirname,'../',
+  require('../package.json').main))
 var UNCHECKED = fs.readFileSync(path.join(__dirname,
   '../dist/regl.min.js')).toString()
 
@@ -25,8 +27,9 @@ ReplaceREGL.prototype._flush = function (cb) {
 }
 
 module.exports = function (file, options) {
+  var nfile = path.normalize(file)
   if ((options._flags && options._flags.debug) ||
-    path.normalize(file) !== REGL_PATH) {
+    (nfile !== REGL_PATH && nfile !== REGL_MAIN_PATH)) {
     return new PassThrough()
   }
   return new ReplaceREGL()


### PR DESCRIPTION
Previously, the file check in the browserify transform failed, resulting in large bundle sizes:

```
$ browserify -r regl | wc -c
272977
```

With this patch, the file sizes are back down to expected levels:

```
$ browserify -r regl | wc -c
75258
```

and with `--debug` you get the debugging symbols:

```
$ browserify --debug -r regl | wc -c
713677
$ browserify --debug -r regl | grep assert | wc -l
38
~ $ browserify -r regl | grep assert | wc -l
0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/402)
<!-- Reviewable:end -->
