### PR TITLE
frameSafe

### DIFF
--- a/API.md
+++ b/API.md
@@ -2506,6 +2506,8 @@ tick.cancel()
 
 It is possible to manage framecallbacks manually, however before any loop it is essential to call `regl.poll()` which updates all timers and viewports.
 
+There is also a convenience function `regl.frameSafe` that wraps `regl.frame` inside a `try/catch` block to prevent browser console to be flooded by error message and calls `frame.cancel` whenever the loop function throws (but not `regl.destroy`).
+
 * * *
 
 ### Extensions

--- a/regl.js
+++ b/regl.js
@@ -456,6 +456,19 @@ module.exports = function wrapREGL (args) {
     }
   }
 
+  function frameSafe(frameFunc) {
+    // as proposed here: https://github.com/regl-project/regl/issues/386
+    var loop = frame(function () {
+      try {
+        frameFunc.apply(undefined, arguments)
+      } catch (err) {
+        loop.cancel()
+        throw err
+      }
+    })
+    return loop
+  }
+
   // poll viewport
   function pollViewport () {
     var viewport = nextState.viewport
@@ -558,6 +571,7 @@ module.exports = function wrapREGL (args) {
 
     // Frame rendering
     frame: frame,
+    frameSafe: frameSafe,
     on: addListener,
 
     // System limits


### PR DESCRIPTION
A convenience function `regl.frameSafe` that wraps `regl.frame` inside a `try/catch` block, plus a test and (small) documentation description.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/408)
<!-- Reviewable:end -->
