### PR TITLE
Typescript declarations

### DIFF
--- a/API.md
+++ b/API.md
@@ -2627,12 +2627,12 @@ regl exposes info about the WebGL context limits and capabilities via the `regl.
 | `textureCount`               | The number of textures currently allocated                                 |
 | `cubeCount`                  | The number of cube maps currently allocated                                |
 | `renderbufferCount`          | The number of renderbuffers currently allocated                            |
+| `maxTextureUnits`            | The maximum number of texture units used                                   |
 | `getTotalTextureSize()`      | The total amount of memory allocated for textures and cube maps            |
 | `getTotalBufferSize()`       | The total amount of memory allocated for array buffers and element buffers |
 | `getTotalRenderbufferSize()` | The total amount of memory allocated for renderbuffers                     |
 | `getMaxUniformsCount()`      | The maximum number of uniforms in any shader                               |
 | `getMaxAttributesCount()`    | The maximum number of attributes in any shader                             |
-| `maxTextureUnits()`          | The maximum number of texture units used                                   |
 
 * * *
 

--- a/API.md
+++ b/API.md
@@ -686,7 +686,8 @@ var command = regl({
 
 **Notes**
 
--   To specify uniforms in nested structs use the fully qualified path with dot notation
+-   To specify uniforms in GLSL structs use the fully qualified path with dot notation.
+-   To specify uniforms in GLSL arrays use the fully qualified path with bracket notation.
 -   Matrix uniforms are specified as flat length n^2 arrays without transposing
 
 **Related WebGL APIs**

--- a/API.md
+++ b/API.md
@@ -1739,6 +1739,7 @@ A data source from an image can be one of the following types:
 | `premultiplyAlpha` | Premultiply alpha when unpacking                                                                                                                                 | `false`     |
 | `colorSpace`       | Sets colorspace conversion                                                                                                                                       | `'none'`    |
 | `data`             | Image data for the texture                                                                                                                                       | `null`      |
+| `copy`    |        | Copy the pixels in the current frame buffer. Cannot be used with `data` prop.                                                                                    | `false`     |
 | `channels`             | Number of channels for the texture format                                                                                                                                       | `null`      |
 
 -   `mipmap`. If `boolean`, then it sets whether or not we should regenerate the mipmaps. If a `string`, it allows you to specify a hint to the mipmap generator. It can be one of the hints below

--- a/API.md
+++ b/API.md
@@ -2606,6 +2606,7 @@ regl exposes info about the WebGL context limits and capabilities via the `regl.
 | `renderer`                | `gl.RENDERER`                                                       |
 | `vendor`                  | `gl.VENDOR`                                                         |
 | `version`                 | `gl.VERSION`                                                        |
+| `textureFormats`          | A list of all supported texture formats                             |
 
 **Relevant WebGL APIs**
 

--- a/API.md
+++ b/API.md
@@ -2255,18 +2255,20 @@ var texFBO = regl.framebuffer({
 })
 ```
 
-| Property       | Description                                                                                                                                                            | Default                  |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `width`        | Sets the width of the framebuffer                                                                                                                                      | `gl.drawingBufferWidth`  |
-| `height`       | Sets the height of the framebuffer                                                                                                                                     | `gl.drawingBufferHeight` |
-| `color`        | An optional array of either textures renderbuffers for the color attachment.                                                                                           |                          |
-| `depth`        | If boolean, then toggles the depth attachment.  Otherwise if a renderbuffer/texture sets the depth attachment.                                                         | `true`                   |
-| `stencil`      | If boolean, then toggles the stencil attachment.  Otherwise if a renderbuffer sets the stencil attachment.                                                             | `true`                   |
-| `depthStencil` | If boolean, then toggles both the depth and stencil attachment.  Otherwise if a renderbuffer/texture sets the combined depth/stencil attachment.                       | `true`                   |
-| `colorFormat`  | Sets the format of the color buffer.  Ignored if color                                                                                                                 | `'rgba'`                 |
-| `colorType`    | Sets the type of the color buffer if it is a texture                                                                                                                   | `'uint8'`                |
-| `colorCount`   | Sets the number of color buffers. Values > 1 require [WEBGL_draw_buffers](https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/)                       | `1`                      |
-| `depthTexture` | Toggles whether depth/stencil attachments should be in texture. Requires [WEBGL_depth_texture](https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/) | `false`                  |
+| Property         | Description                                                                                                                                                            | Default                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `shape`          | Sets the dimensions [width, height] for the framebuffer.                                                                                                               |                          |
+| `radius`         | Sets the dimensions `radius` x `radius` for the framebuffer.                                                                                                           |                          |
+| `width`          | Sets the width of the framebuffer                                                                                                                                      | `gl.drawingBufferWidth`  |
+| `height`         | Sets the height of the framebuffer                                                                                                                                     | `gl.drawingBufferHeight` |
+| `color`/`colors` | A texture or renderbuffer (or an array of these) for the color attachment.                                                                                             |                          |
+| `depth`          | If boolean, toggles the depth attachment. If a renderbuffer or texture, sets the depth attachment.                                                                     | `true`                   |
+| `stencil`        | If boolean, toggles the stencil attachment. If a renderbuffer or texture, sets the stencil attachment.                                                                 | `true`                   |
+| `depthStencil`   | If boolean, toggles both the depth and stencil attachments.  If a renderbuffer or texture, sets the combined depth/stencil attachment.                                 | `true`                   |
+| `colorFormat`    | Sets the format of the color buffer.  Ignored if `color` is specified.                                                                                                 | `'rgba'`                 |
+| `colorType`      | Sets the type of the color buffer if it is a texture.                                                                                                                  | `'uint8'`                |
+| `colorCount`     | Sets the number of color buffers. Values > 1 require [WEBGL_draw_buffers](https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/)                       | `1`                      |
+| `depthTexture`   | Toggles whether depth/stencil attachments should be in texture. Requires [WEBGL_depth_texture](https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/) | `false`                  |
 
 | Color format | Description       | Attachment   | Notes                                                                                                                     |
 | ------------ | ----------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
@@ -2279,16 +2281,16 @@ var texFBO = regl.framebuffer({
 | `'rgba32f'`  | `gl.RGBA32F`      | Renderbuffer | only if [WEBGL_color_buffer_float](https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/) supported |
 | `'srgba'`    | `gl.SRGB8_ALPHA8` | Renderbuffer | only if [EXT_sRGB](https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/) supported                                 |
 
-| Color type     | Description                                                                                                                |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `'uint8'`      | `gl.UNSIGNED_BYTE`                                                                                                         |
-| `'half float'` | 16 bit float, requires [OES_texture_half_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/) |
-| `'float'`      | 32 bit float, requires [OES_texture_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_float/)           |
+| Color type     | Description                                                                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `'uint8'`      | `gl.UNSIGNED_BYTE`                                                                                                                                |
+| `'half float'` | `ext.HALF_FLOAT_OES` (16-bit float), requires [OES_texture_half_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/) |
+| `'float'`      | `gl.FLOAT` (32-bit float), requires [OES_texture_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_float/)                     |
 
 **Notes**
 
--   If `color` is not specified, then color attachments are created automatically
--   Instead of passing width/height, it is also possible to pass in `shape` to the framebuffer constructor.
+-   If neither `color` nor `colors` is specified, then color attachments are created automatically.
+-   `shape`, `radius`, and `width`/`height` are alternative (and mutually exclusive) means for setting the size of the framebuffer.
 
 **Relevant WebGL APIs**
 
@@ -2376,31 +2378,35 @@ var cubeAlt = regl.framebufferCube({
 })
 ```
 
-| Parameter      | Description                      |
-| -------------- | -------------------------------- |
-| `radius`       | The size of the cube buffer      |
-| `color`        | The color buffer attachment      |
-| `colorFormat`  | Format of color buffer to create |
-| `colorType`    | Type of color buffer             |
-| `colorCount`   | Number of color attachments      |
-| `depth`        | Depth buffer attachment          |
-| `stencil`      | Stencil buffer attachment        |
-| `depthStencil` | Depth-stencil attachment         |
+| Property         | Description                                                                                                                                                            | Default                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `shape`          | Sets the dimensions [width, height] for each face of the cube. Width must equal height.                                                                                |                          |
+| `radius`         | Sets the dimensions `radius` x `radius` for each face of the cube.                                                                                                     |                          |
+| `width`          | Sets the width dimension for each face of the cube. Must equal `height`.                                                                                               | `gl.drawingBufferWidth`  |
+| `height`         | Sets the height dimension for each face of the cube. Must equal `width`.                                                                                               | `gl.drawingBufferHeight` |
+| `color`/`colors` | A TextureCube or array of TextureCubes for the color attachment.                                                                                                       |                          |
+| `depth`          | If boolean, toggles the depth attachment. If texture, sets the depth attachment.                                                                                       | `true`                   |
+| `stencil`        | If boolean, toggles the stencil attachment. If texture, sets the stencil attachment.                                                                                   | `true`                   |
+| `depthStencil`   | If boolean, toggles both the depth and stencil attachments.  If texture, sets the combined depth/stencil attachment.                                                   | `true`                   |
+| `colorFormat`    | Sets the format of the color buffer.  Ignored if `color` is specified.                                                                                                 | `'rgba'`                 |
+| `colorType`      | Sets the type of the color buffer.                                                                                                                                     | `'uint8'`                |
+| `colorCount`     | Sets the number of color buffers. Values > 1 require [WEBGL_draw_buffers](https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/)                       | `1`                      |
+| `depthTexture`   | Toggles whether depth/stencil attachments should be in texture. Requires [WEBGL_depth_texture](https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/) | `false`                  |
 
 | Color format | Description | Attachment |
 | ------------ | ----------- | ---------- |
 | `'rgba'`     | `gl.RGBA`   | Texture    |
 
-| Color type     | Description                                                                                                                |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `'uint8'`      | `gl.UNSIGNED_BYTE`                                                                                                         |
-| `'half float'` | 16 bit float, requires [OES_texture_half_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/) |
-| `'float'`      | 32 bit float, requires [OES_texture_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_float/)           |
+| Color type     | Description                                                                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `'uint8'`      | `gl.UNSIGNED_BYTE`                                                                                                                                |
+| `'half float'` | `ext.HALF_FLOAT_OES` (16-bit float), requires [OES_texture_half_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/) |
+| `'float'`      | `gl.FLOAT` (32-bit float), requires [OES_texture_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_float/)                     |
 
 **Notes**
 
--   The specified depth/stencil/depth-stencil attachment will be reused
-    for all 6 cube faces.
+-   The specified depth/stencil/depth-stencil attachment will be reused for all 6 cube faces.
+-   `shape`, `radius`, and `width`/`height` are alternative (and mutually exclusive) means for setting the size of the framebuffer.
 
 #### Cube framebuffer update
 

--- a/API.md
+++ b/API.md
@@ -241,8 +241,8 @@ var regl = require('regl')(require('gl')(256, 256))
 | Options              | Meaning                                                                                                                                                                       |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `gl`                 | A reference to a WebGL rendering context. (Default created from canvas)                                                                                                       |
-| `canvas`             | A reference to an HTML canvas element. (Default created and appending to container)                                                                                           |
-| `container`          | A container element which regl inserts a canvas into. (Default `document.body`)                                                                                               |
+| `canvas`             | A reference to an HTML canvas element. (Default created and appended to container)                                                                                           |
+| `container`          | A container element into which regl inserts a canvas. (Default `document.body`)                                                                                               |
 | `attributes`         | The [context creation attributes](https://www.khronos.org/registry/webgl/specs/1.0/#WEBGLCONTEXTATTRIBUTES) passed to the WebGL context constructor.  See below for defaults. |
 | `pixelRatio`         | A multiplier which is used to scale the canvas size relative to the container.  (Default `window.devicePixelRatio`)                                                           |
 | `extensions`         | A list of extensions that must be supported by WebGL context. Default `[]`                                                                                                    |

--- a/API.md
+++ b/API.md
@@ -2634,6 +2634,10 @@ regl exposes info about the WebGL context limits and capabilities via the `regl.
 | `getMaxUniformsCount()`      | The maximum number of uniforms in any shader                               |
 | `getMaxAttributesCount()`    | The maximum number of attributes in any shader                             |
 
+**Notes**
+-   The functions `getTotalTextureSize`, `getTotalBufferSize`, `getTotalRenderbufferSize`, `getMaxUniformsCount`, and `getMaxAttributesCount` are only available if `regl` is initialized with the option `profile: true`.
+
+
 * * *
 
 ### Clocks and timers

--- a/dist/regl.d.ts
+++ b/dist/regl.d.ts
@@ -1,0 +1,1706 @@
+// Type definitions for regl 1.3.1
+// Project: regl
+// Definitions by: Stepan Stolyarov <stepan.stolyarov@gmail.com>, David Schneider <github.com/davschne>
+
+/*~ Note that ES6 modules cannot directly export callable functions.
+ *~ This file should be imported using the CommonJS-style:
+ *~
+ *~ ```typescript
+ *~ import REGL = require('regl');
+ *~ ```
+ *~
+ *~ Refer to the documentation to understand common
+ *~ workarounds for this limitation of ES6 modules.
+ */
+
+/*~ This module is a UMD module that exposes a global function `createREGL`. */
+export as namespace createREGL;
+
+export = REGL;
+
+/**
+ * Creates a full screen canvas element and a WebGL rendering context.
+ */
+declare function REGL(): REGL.Regl;
+
+/**
+ * Creates a WebGL rendering context using an element selected by `selector`.
+ * This may be:
+ * 1) an existing HTMLCanvasElement
+ * 2) an element that contains a canvas
+ * 3) an element in which you'd like `regl` to create a canvas
+ *
+ * @param selector an argument to `document.querySelector`
+ */
+declare function REGL(selector: string): REGL.Regl;
+
+/**
+ * Creates a canvas element and a WebGL rendering context in a given container element.
+ *
+ * @param container an HTML element
+ */
+declare function REGL(container: HTMLElement): REGL.Regl;
+
+/**
+ * Creates a WebGL rendering context using a `<canvas>` element.
+ *
+ * @param canvas HTML canvas element
+ */
+declare function REGL(canvas: HTMLCanvasElement): REGL.Regl;
+
+/**
+ * Wraps an existing WebGL rendering context.
+ *
+ * @param gl WebGL rendering context
+ */
+declare function REGL(gl: WebGLRenderingContext): REGL.Regl;
+
+/**
+ * Creates a WebGL according to specified `options`
+ */
+declare function REGL(options: REGL.InitializationOptions): REGL.Regl;
+
+declare namespace REGL {
+  /**
+   * `Regl` represents the object/function returned from the `REGL` constructor. It exposes the
+   * entire public interface of the `regl` library.
+   */
+  export interface Regl {
+    /**
+     * The context creation attributes passed to the WebGL context constructor.
+     */
+    readonly attributes: WebGLContextAttributes;
+    /**
+     * `regl` is designed in such a way that you should never have to directly access the underlying
+     * WebGL context. However, if you really absolutely need to do this for some reason (for example
+     * to interface with an external library), you can still get a reference to the WebGL context
+     * via the property `_gl`.
+     */
+    readonly _gl: WebGLRenderingContext;
+    /**
+     * `regl` exposes info about the WebGL context limits and capabilities via the `limits` object.
+     */
+    readonly limits: REGL.Limits;
+    /**
+     * `regl` tracks several metrics for performance monitoring. These can be read using the `stats` object.
+     */
+    readonly stats: REGL.Stats;
+
+    /**
+     * Creates a new REGL command. The resulting command, when executed,
+     * will set a WebGL state machine to a specified `state`.
+     */
+    <
+      Uniforms extends {} = {},
+      Attributes extends {} = {},
+      Props extends {} = {},
+      OwnContext extends {} = {},
+      ParentContext extends REGL.DefaultContext = REGL.DefaultContext
+    >(
+      drawConfig: REGL.DrawConfig<Uniforms, Attributes, Props, OwnContext, ParentContext>,
+    ): REGL.DrawCommand<ParentContext & OwnContext, Props>;
+
+    /**
+     * Clears selected buffers to specified values.
+     * If an option is not present, then the corresponding buffer is not cleared.
+     * Relevant WebGL API: `gl.clear`
+     */
+    clear(options: REGL.ClearOptions): void;
+
+    /* Reading pixels */
+
+    /**
+     * Read entire screen.
+     * NB: Reading into a Float32Array requires OES_texture_float.
+     */
+    read<T extends Uint8Array | Float32Array = Uint8Array>(): T;
+
+    /**
+     * Read entire screen into an existing TypedArray.
+     * NB: Reading into a Float32Array requires OES_texture_float.
+     */
+    read<T extends Uint8Array | Float32Array>(data: T): T;
+
+    /**
+     * Read a selected region of screen or framebuffer.
+     * NB: Reading into a Float32Array requires OES_texture_float.
+     */
+    read<T extends Uint8Array | Float32Array = Uint8Array>(options: REGL.ReadOptions<T>): T;
+
+    /**
+     * Dynamic variable binding
+     *
+     * `prop`, `context`, and `this` generate DynamicVariables, which can be used as values in a
+     * REGL.DrawConfig object. A DynamicVariable is an abstraction that will render a value only
+     * when the DrawCommand with which it's associated is invoked.
+     */
+
+    /* Retrieve the property `name` passed when the draw command is executed. */
+    prop<Props extends {}, Key extends keyof Props>(name: Key): DynamicVariable<Props[Key]>;
+    /* Retrieve the context property `name` when the draw command is executed. */
+    context<Context extends REGL.DefaultContext, K extends keyof Context>(name: K): DynamicVariable<Context[K]>;
+    /* Retrieve the property `name` of the object in whose context the draw command is executing. */
+    this<This extends {}, Key extends keyof This>(name: Key): DynamicVariable<This[Key]>;
+
+    /* Drawing */
+
+    /** Executes an empty draw command. */
+    draw(): void;
+
+    /* Resource creation */
+
+    /** Creates an empty buffer of length `length`. */
+    buffer(length: number): REGL.Buffer;
+    /** Creates a buffer with the provided `data`. */
+    buffer(data: REGL.BufferData): REGL.Buffer;
+    /** Creates a buffer using creation `options`. */
+    buffer(options: REGL.BufferOptions): REGL.Buffer;
+
+    /* Creates an Elements object with the provided `data`. */
+    elements(data: REGL.ElementsData): REGL.Elements;
+    /* Creates an Elements object using creation `options`. */
+    elements(options: REGL.ElementsOptions): REGL.Elements;
+
+    /* Creates a 2D Texture of dimensions 1 x 1. */
+    texture(): REGL.Texture2D;
+    /* Creates a 2D Texture of dimensions `radius` x `radius`. */
+    texture(radius: number): REGL.Texture2D;
+    /* Creates a 2D Texture of dimensions `width` x `height`. */
+    texture(width: number, height: number): REGL.Texture2D;
+    /* Creates a 2D Texture using the provided `data`. */
+    texture(data: REGL.TextureImageData): REGL.Texture2D;
+    /* Creates a 2D Texture using creation `options`. */
+    texture(options: REGL.Texture2DOptions): REGL.Texture2D;
+
+    /* Creates a cube-map texture with faces of dimensions 1 x 1. */
+    cube(): REGL.TextureCube;
+    /* Creates a cube-map texture with faces of dimensions `radius` x `radius`. */
+    cube(radius: number): REGL.TextureCube;
+    /* Creates a cube-map texture using the provided image data for the six faces. */
+    cube(
+      posXData: REGL.TextureImageData, negXData: REGL.TextureImageData,
+      posYData: REGL.TextureImageData, negYData: REGL.TextureImageData,
+      posZData: REGL.TextureImageData, negZData: REGL.TextureImageData
+    ): REGL.TextureCube;
+    /* Creates a cube-map texture using the provided creation options for the six faces. */
+    cube(
+      posXOptions: REGL.Texture2DOptions, negXOptions: REGL.Texture2DOptions,
+      posYOptions: REGL.Texture2DOptions, negYOptions: REGL.Texture2DOptions,
+      posZOptions: REGL.Texture2DOptions, negZOptions: REGL.Texture2DOptions,
+    ): REGL.TextureCube;
+    /* Creates a cube-map texture using creation `options`. */
+    cube(options: REGL.TextureCubeOptions): REGL.TextureCube;
+
+    /* Creates a Renderbuffer of dimensions 1 x 1. */
+    renderbuffer(): REGL.Renderbuffer;
+    /* Creates a Renderbuffer of dimensions `radius` x `radius`. */
+    renderbuffer(radius: number): REGL.Renderbuffer;
+    /* Creates a Renderbuffer of dimensions `width` x `height`. */
+    renderbuffer(width: number, height: number): REGL.Renderbuffer;
+    /* Creates a Renderbuffer using creation `options`. */
+    renderbuffer(options: REGL.RenderbufferOptions): REGL.Renderbuffer;
+
+    /* Creates a Framebuffer of dimensions 1 x 1. */
+    framebuffer(): REGL.Framebuffer2D;
+    /* Creates a Framebuffer of dimensions `radius` x `radius`. */
+    framebuffer(radius: number): REGL.Framebuffer2D;
+    /* Creates a Framebuffer of dimensions `width` x `height`. */
+    framebuffer(width: number, height: number): REGL.Framebuffer2D;
+    /* Creates a Framebuffer using creation `options`. */
+    framebuffer(options: REGL.FramebufferOptions): REGL.Framebuffer2D;
+
+    /* Creates a FramebufferCube whose faces have dimensions 1 x 1. */
+    framebufferCube(): REGL.FramebufferCube;
+    /* Creates a FramebufferCube whose faces have dimensions `radius` x `radius`. */
+    framebufferCube(radius: number): REGL.FramebufferCube;
+    /* Creates a FramebufferCube using creation `options`. */
+    framebufferCube(options: REGL.FramebufferCubeOptions): REGL.FramebufferCube;
+
+    /* Events and listeners */
+
+    /**
+     * Registers a `callback` to be called on each animation frame.
+     *
+     * This method integrates with `requestAnimationFrame` and context loss
+     * events. It also calls `gl.flush` and drains several internal buffers,
+     * so you should try to do all your rendering to the drawing buffer within
+     * the frame callback.
+     */
+    frame(callback: REGL.FrameCallback): REGL.Cancellable;
+
+    /**
+     * Registers a handler function to be called when the associated `regl` event is fired.
+     */
+    on(type: 'frame', callback: REGL.FrameCallback): REGL.Cancellable
+    on(type: 'lost' | 'restore' | 'destroy', callback: () => void): REGL.Cancellable;
+
+    /**
+     * Test if an extension is present. Argument is case insensitive.
+     *
+     * For more information on WebGL extensions, see the WebGL extension registry.
+     *
+     * Relevant WebGL APIs
+     *
+     * - [WebGL Extension Registry](https://www.khronos.org/registry/webgl/extensions/)
+     * - gl.getExtension
+     * - gl.getSupportedExtensions
+     *
+     * @param name case-insensitive name of WebGL extension
+     */
+    hasExtension(name: string): boolean;
+
+    /**
+     * Updates the values of internal times and recalculates the size of viewports.
+     */
+    poll(): void;
+
+    /**
+     * Returns Total time elapsed since regl was initialized in seconds.
+     */
+    now(): number;
+
+    /**
+     * Destroys the gl context and releases all associated resources.
+     */
+    destroy(): void;
+
+    /**
+     * `regl` is designed in such a way that you should never have to directly access the underlying
+     * WebGL context. However, if you really absolutely need to do this for some reason (for example
+     * to interface with an external library), you can still get a reference to the WebGL context
+     * via the property `REGL._gl`. Note, though, that if you have changed the WebGL state, you must
+     * call `_refresh` to restore the `regl` state in order to prevent rendering errors.
+     */
+    _refresh(): void;
+  }
+
+  interface InitializationOptions {
+    /** A reference to a WebGL rendering context. (Default created from canvas) */
+    gl?: WebGLRenderingContext;
+    /** An HTML canvas element or a selector string to find this element. (Default created and appended to container)*/
+    canvas?: string | HTMLCanvasElement;
+    /** A container element into which regl inserts a canvas or a selector string to find this element. (Default document.body) */
+    container?: string | HTMLElement;
+    /** The context creation attributes passed to the WebGL context constructor. */
+    attributes?: WebGLContextAttributes;
+    /** A multiplier which is used to scale the canvas size relative to the container. (Default window.devicePixelRatio) */
+    pixelRatio?: number;
+    /** A list of extensions that must be supported by WebGL context. Default [] */
+    extensions?: string | string[];
+    /** A list of extensions which are loaded opportunistically. Default [] */
+    optionalExtensions?: string | string[];
+    /** If set, turns on profiling for all commands by default. (Default false) */
+    profile?: boolean;
+    /** An optional callback which accepts a pair of arguments, (err, regl) that is called after the application loads. If not specified, context creation errors throw */
+    onDone?: (err: Error | null, regl?: Regl) => void;
+  }
+
+  interface DefaultContext {
+    /** The number of frames rendered */
+    readonly tick: number;
+    /** Total time elapsed since regl was initialized in seconds */
+    readonly time: number;
+    /** Width of the current viewport in pixels */
+    readonly viewportWidth: number;
+    /** Height of the current viewport in pixels */
+    readonly viewportHeight: number;
+    /** Width of the WebGL context drawing buffer */
+    readonly drawingBufferWidth: number;
+    /** Height of the WebGL context drawing buffer */
+    readonly drawingBufferHeight: number;
+    /** The pixel ratio of the drawing buffer */
+    readonly pixelRatio: number;
+  }
+
+  type UserContext<
+    ParentContext extends REGL.DefaultContext,
+    OwnContext extends {},
+    Props extends {}
+  > = {
+    [Key in keyof OwnContext]: MaybeDynamic<OwnContext[Key], ParentContext, Props>;
+  };
+
+  interface Cancellable {
+    cancel(): void;
+  }
+
+  /**
+   * A handler function invoked when `regl` fires the "frame" event. It is passed the default Context.
+   */
+  type FrameCallback = (context: REGL.DefaultContext) => void;
+
+  interface DynamicVariable<Return> {
+    /**
+     * This type is supposed to be opaque. Properties are listed only because TS casts _anything_ to `DynamicVariable`.
+     * The type parameter `Return`, though unused in the body of the interface, is useful as a
+     * marker to ensure the correct type is rendered when the associated `DrawCommand` is invoked.
+     */
+    readonly id: number;
+    readonly type: number;
+    readonly data: string;
+  }
+
+  type DynamicVariableFn<
+    Return,
+    Context extends REGL.DefaultContext = REGL.DefaultContext,
+    Props extends {} = {}
+  > =
+    (context: Context, props: Props, batchId: number) => Return;
+
+  type MaybeDynamic<Type, Context extends REGL.DefaultContext, Props extends {}> =
+    Type |
+    DynamicVariable<Type> |
+    DynamicVariableFn<Type, Context, Props>;
+
+  interface ClearOptions {
+    /**
+     * RGBA values (range 0-1) to use when the color buffer is cleared. Initial value: [0, 0, 0, 0].
+     * Relevant WebGL API: `gl.clearColor`
+     */
+    color?: REGL.Vec4;
+    /**
+     * Depth value (range 0-1) to use when the depth buffer is cleared. Initial value: 1.
+     * Relevant WebGL API: `gl.clearDepth`
+     */
+    depth?: number;
+    /**
+     * The index used when the stencil buffer is cleared. Initial value: 0.
+     * Relevant WebGL API: `gl.clearStencil`
+     */
+    stencil?: number;
+    /**
+     * Sets the target framebuffer to clear (if unspecified, uses the current framebuffer object).
+     * Relevant WebGL API: `gl.bindFrameBuffer`
+     */
+    framebuffer?: REGL.Framebuffer | null;
+  }
+
+  interface ReadOptions<T = Uint8Array> {
+    /** An optional TypedArray which gets the result of reading the pixels. (Default: `null`, i.e. return a new TypedArray) */
+    data?: T | null;
+    /** The x-offset of the upper-left corner of the rectangle in pixels. (Default: `0`) */
+    x?: number;
+    /** The y-offset of the upper-left corner of the rectangle in pixels. (Default: `0`) */
+    y?: number;
+    /** The width of the rectangle in pixels. (Default: current framebuffer width) */
+    width?: number;
+    /** The height of the rectangle in pixels (Default: current framebuffer height) */
+    height?: number;
+    /** Sets the framebuffer to read pixels from. (Default: currently bound framebuffer) */
+    framebuffer?: REGL.Framebuffer;
+  }
+
+  /**
+   * Commands can be nested using scoping. If a `DrawCommand` is passed a `CommandBodyFn`, then the
+   * `DrawCommand` is evaluated and its state variables are saved as the defaults for all
+   * `DrawCommand`s invoked within the `CommandBodyFn`.
+   *
+   * @param context       REGL context
+   * @param props         additional parameters of a draw call
+   * @param batchId       index of a command in a batch call
+   */
+  type CommandBodyFn<
+    Context extends REGL.DefaultContext = REGL.DefaultContext,
+    Props extends {} = {}
+  > = (context: Context, props: Props, batchId: number) => void;
+
+  /**
+   * Draw commands are the fundamental abstraction in regl. A draw command wraps up all of the WebGL
+   * state associated with a draw call (either drawArrays or drawElements) and packages it into a
+   * single reusable function.
+   */
+  interface DrawCommand<
+    Context extends REGL.DefaultContext = REGL.DefaultContext,
+    Props extends {} = {}
+  > {
+    readonly stats: REGL.CommandStats;
+
+    /** Run a command once. */
+    (body?: REGL.CommandBodyFn<Context, Props>): void;
+    /** Run a command `count` times. */
+    (count: number, body?: REGL.CommandBodyFn<Context, Props>): void;
+    /** Run a command with props. */
+    (props: Partial<Props>, body?: REGL.CommandBodyFn<Context, Props>): void;
+    /** Run a command batch. */
+    (props: Array<Partial<Props>>, body?: REGL.CommandBodyFn<Context, Props>): void;
+  }
+
+  interface DrawConfig<
+    Uniforms extends {} = {},
+    Attributes extends {} = {},
+    Props extends {} = {},
+    OwnContext extends {} = {},
+    ParentContext extends REGL.DefaultContext = REGL.DefaultContext
+  > {
+
+    /* Shaders */
+
+    /** Source code of vertex shader */
+    vert?: MaybeDynamic<string, ParentContext & OwnContext, Props>;
+    /** Source code of fragment shader */
+    frag?: MaybeDynamic<string, ParentContext & OwnContext, Props>;
+
+    /**
+     * Object mapping user-defined keys to user-defined values to be accessed via `DynamicVariable`s
+     * or `DynamicVariableFn`s elsewhere in the `DrawConfig` or in scoped `DrawCommand`s.
+     * Context variables in `regl` are computed before any other parameters and can also be passed
+     * from a scoped command to any sub-commands.
+     * Both `DynamicVariable`s and `DynamicVariableFn`s can be used as values in the context object,
+     * making it possible to define new context properties derived from existing context properties
+     * or from `props`.
+     */
+    context?: REGL.UserContext<ParentContext, OwnContext, Props>,
+
+    /**
+     * Object mapping names of uniform variables to their values.
+     * To specify uniforms in GLSL structs use the fully qualified path with dot notation.
+     *  example: `'nested.value': 5.3`
+     * To specify uniforms in GLSL arrays use the fully qualified path with bracket notation.
+     *  example: `'colors[0]': [0, 1, 0, 1]`
+     *
+     * Related WebGL APIs
+     *
+     * - gl.getUniformLocation
+     * - gl.uniform
+     */
+    uniforms?: REGL.MaybeDynamicUniforms<Uniforms, ParentContext & OwnContext, Props>,
+
+    /**
+     * Object mapping names of attribute variables to their values.
+     *
+     * Related WebGL APIs
+     *
+     * - gl.vertexAttribPointer
+     * - gl.vertexAttrib
+     * - gl.getAttribLocation
+     * - gl.vertexAttibDivisor
+     * - gl.enableVertexAttribArray, gl.disableVertexAttribArray
+     */
+    attributes?: REGL.MaybeDynamicAttributes<Attributes, ParentContext & OwnContext, Props>,
+
+    /* Drawing */
+
+    /**
+     * Sets the primitive type. (Default: 'triangles', or inferred from `elements`)
+     */
+    primitive?: MaybeDynamic<REGL.PrimitiveType, ParentContext & OwnContext, Props>;
+    /**
+     * Number of vertices to draw. (Default: 0, or inferred from `elements`)
+     */
+    count?: MaybeDynamic<number, ParentContext & OwnContext, Props>;
+    /**
+     * Offset of primitives to draw. (Default: 0, or inferred from `elements`)
+     */
+    offset?: MaybeDynamic<number, ParentContext & OwnContext, Props>;
+    /**
+     * Number of instances to draw. (Default: 0)
+     *
+     * Only applicable if the `ANGLE_instanced_arrays` extension is present.
+     */
+    instances?: MaybeDynamic<number, ParentContext & OwnContext, Props>;
+    /**
+     * Element array buffer. (Default: `null`)
+     *
+     * Elements must be either an instance of REGL.Elements or else the arguments to REGL.Elements.
+     * If `elements` is specified while `primitive`, `count` and `offset` are not,
+     * then these values may be inferred from the state of the element array buffer.
+     */
+    elements?: MaybeDynamic<
+      REGL.Elements | ElementsData | ElementsOptions | null,
+      ParentContext & OwnContext,
+      Props
+    >;
+
+    /* Render target */
+
+    /**
+     * A framebuffer to be used as a target for drawing. (Default: `null`)
+     * Passing null sets the framebuffer to the drawing buffer.
+     * Updating the render target will modify the viewport.
+     *
+     * Related WebGL APIs
+     *
+     * - [gl.bindFramebuffer](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindFramebuffer.xml)
+     */
+    framebuffer?: MaybeDynamic<REGL.Framebuffer | null, ParentContext & OwnContext, Props>;
+
+    /* Profiling */
+
+    /**
+     * If set, turns on profiling for this command. (Default: `false`)
+     * Profiling stats can be accessed via the `stats` property of the `DrawCommand`.
+     */
+    profile?: MaybeDynamic<boolean, ParentContext & OwnContext, Props>;
+
+    /* Depth buffer */
+
+    /**
+     * Related WebGL APIs
+     *
+     * - gl.depthFunc
+     * - gl.depthMask
+     * - gl.depthRange
+     */
+    depth?: MaybeDynamic<REGL.DepthTestOptions, ParentContext & OwnContext, Props>;
+
+    /* Blending */
+
+    /**
+     * Related WebGL APIs
+     *
+     * - gl.blendEquationSeparate
+     * - gl.blendFuncSeparate
+     * - gl.blendColor
+     */
+    blend?: MaybeDynamic<REGL.BlendingOptions, ParentContext & OwnContext, Props>;
+
+    /* Stencil */
+
+    /**
+     * Related WebGL APIs
+     *
+     * - gl.stencilFunc
+     * - gl.stencilMask
+     * - gl.stencilOpSeparate
+     */
+    stencil?: MaybeDynamic<REGL.StencilOptions, ParentContext & OwnContext, Props>;
+
+    /* Polygon offset */
+
+    /**
+     * Related WebGL APIs
+     *
+     * - gl.polygonOffset
+     */
+    polygonOffset?: MaybeDynamic<REGL.PolygonOffsetOptions, ParentContext & OwnContext, Props>;
+
+    /* Culling */
+
+    cull?: MaybeDynamic<REGL.CullingOptions, ParentContext & OwnContext, Props>;
+
+    /* Front face */
+
+    /* Sets gl.frontFace. Default: 'ccw' */
+    frontFace?: MaybeDynamic<REGL.FaceWindingType, ParentContext & OwnContext, Props>;
+
+    /* Dithering */
+
+    /* Toggles `gl.DITHER`. Default: false */
+    dither?: MaybeDynamic<boolean, ParentContext & OwnContext, Props>;
+
+    /* Line width */
+
+    /* Sets `gl.lineWidth`. Default: 1 */
+    lineWidth?: MaybeDynamic<number, ParentContext & OwnContext, Props>;
+
+    /* Color mask */
+
+    /* Sets `gl.colorMask`. Default: [true, true, true, true] */
+    colorMask?: MaybeDynamic<REGL.BVec4, ParentContext & OwnContext, Props>;
+
+    /* Sample coverage */
+
+    sample?: MaybeDynamic<REGL.SamplingOptions, ParentContext & OwnContext, Props>;
+
+    /* Scissor */
+
+    scissor?: MaybeDynamic<REGL.ScissorOptions, ParentContext & OwnContext, Props>;
+
+    /* Viewport */
+
+    /**
+     * Sets `gl.viewport`. Default: {}
+     * Updating `viewport` will modify the context variables `viewportWidth` and `viewportHeight`.
+     */
+    viewport?: MaybeDynamic<REGL.BoundingBox, ParentContext & OwnContext, Props>;
+  }
+
+  type PrimitiveType =
+    /** gl.POINTS */
+    "points" |
+    /** gl.LINES */
+    "lines" |
+    /** gl.LINE_STRIP */
+    "line strip" |
+    /** gl.LINE_LOOP */
+    "line loop" |
+    /** gl.TRIANGLES */
+    "triangles" |
+    /** gl.TRIANGLE_STRIP */
+    "triangle strip" |
+    /** gl.TRIANGLE_FAN */
+    "triangle fan";
+
+  type Uniform =
+    boolean |
+    number |
+    boolean[] |
+    number[] |
+    Float32Array |
+    Int32Array;
+
+  interface Uniforms {
+    [name: string]: Uniform;
+  }
+
+  type MaybeDynamicUniforms<
+    Uniforms extends REGL.Uniforms,
+    Context extends REGL.DefaultContext,
+    Props extends {}
+  > = {
+    [Key in keyof Uniforms]: MaybeDynamic<Uniforms[Key], Context, Props>;
+  }
+
+  type Attribute =
+    ConstantAttribute |
+    AttributeConfig |
+    REGL.Buffer |
+    REGL.BufferData;
+
+  interface Attributes {
+    [name: string]: Attribute;
+  }
+
+  type MaybeDynamicAttributes<
+    Attributes extends REGL.Attributes,
+    Context extends REGL.DefaultContext,
+    Props extends {}
+  > = {
+    [Key in keyof Attributes]: MaybeDynamic<Attributes[Key], Context, Props>;
+  }
+
+  interface ConstantAttribute {
+    constant: number | number[];
+  }
+
+  interface AttributeConfig {
+    /** A REGLBuffer wrapping the buffer object. (Default: null) */
+    buffer?: REGL.Buffer;
+    /** The offset of the vertexAttribPointer in bytes. (Default: 0) */
+    offset?: number;
+    /** The stride of the vertexAttribPointer in bytes. (Default: 0) */
+    stride?: number;
+    /** Whether the pointer is normalized. (Default: false) */
+    normalized?: boolean;
+    /** The size of the vertex attribute. (Default: Inferred from shader) */
+    size?: number;
+    /** Sets gl.vertexAttribDivisorANGLE. Only supported if the ANGLE_instanced_arrays extension is available. (Default: 0) */
+    divisor?: number;
+  }
+
+  interface DepthTestOptions {
+    /* Toggles `gl.enable(gl.DEPTH_TEST)`. Default: true */
+    enable?: boolean;
+    /* Sets `gl.depthMask`. Default: true */
+    mask?: boolean;
+    /* Sets `gl.depthRange`. Default: [0, 1] */
+    range?: [number, number];
+    /* Sets `gl.depthFunc`. Default: 'less' */
+    func?: REGL.ComparisonOperatorType;
+  }
+
+  type ComparisonOperatorType =
+    /* `gl.NEVER` */
+    "never" |
+    /* `gl.ALWAYS` */
+    "always" |
+    /* `gl.LESS` */
+    "less" | "<" |
+    /* `gl.LEQUAL` */
+    "lequal" | "<=" |
+    /* `gl.GREATER` */
+    "greater" | ">" |
+    /* `gl.GEQUAL` */
+    "gequal" | ">=" |
+    /* `gl.EQUAL` */
+    "equal" | "=" |
+    /* `gl.NOTEQUAL` */
+    "notequal" | "!=";
+
+  interface BlendingOptions {
+    /* Toggles `gl.enable(gl.BLEND)`. Default: false */
+    enable?: boolean;
+    /**
+     * `equation` can be either a string or an object with the fields {rgb, alpha}.
+     * The former corresponds to `gl.blendEquation` and the latter to `gl.blendEquationSeparate`.
+     * Default: 'add'
+     */
+    equation?: REGL.BlendingEquation | REGL.BlendingEquationSeparate;
+    /**
+     * `func` can be an object with the fields {src, dst} or {srcRGB, srcAlpha, dstRGB, dstAlpha},
+     * with the former corresponding to gl.blendFunc and the latter to gl.blendFuncSeparate.
+     * Default: { src: 'src alpha', dst: 'one minus src alpha' }
+     */
+    func?: REGL.BlendingFunctionCombined | REGL.BlendingFunctionSeparate;
+    /* Sets `gl.blendColor` */
+    color?: REGL.Vec4;
+  }
+
+  interface BlendingEquationSeparate {
+    rgb: REGL.BlendingEquation;
+    alpha: REGL.BlendingEquation;
+  }
+
+  type BlendingEquation =
+    /* `gl.FUNC_ADD` */
+    "add" |
+    /* `gl.FUNC_SUBTRACT` */
+    "subtract" |
+    /* `gl.FUNC_REVERSE_SUBTRACT` */
+    "reverse subtract" |
+    /* `gl.MIN_EXT`, requires `EXT_blend_minmax` */
+    "min" |
+    /* `gl.MAX_EXT`, requires `EXT_blend_minmax` */
+    "max";
+
+  interface BlendingFunctionCombined {
+    src: REGL.BlendingFunction;
+    dst: REGL.BlendingFunction;
+  }
+
+  interface BlendingFunctionSeparate {
+    srcRGB: REGL.BlendingFunction;
+    srcAlpha: REGL.BlendingFunction;
+    dstRGB: REGL.BlendingFunction;
+    dstAlpha: REGL.BlendingFunction;
+  }
+
+  type BlendingFunction =
+    /* `gl.ZERO` */
+    "zero" | 0 |
+    /* `gl.ONE` */
+    "one" | 1 |
+    /* `gl.SRC_COLOR` */
+    "src color" |
+    /* `gl.ONE_MINUS_SRC_COLOR` */
+    "one minus src color" |
+    /* `gl.SRC_ALPHA` */
+    "src alpha" |
+    /* `gl.ONE_MINUS_SRC_ALPHA` */
+    "one minus src alpha" |
+    /* `gl.DST_COLOR` */
+    "dst color" |
+    /* `gl.ONE_MINUS_DST_COLOR` */
+    "one minus dst color" |
+    /* `gl.DST_ALPHA` */
+    "dst alpha" |
+    /* `gl.ONE_MINUS_DST_ALPHA` */
+    "one minus dst alpha" |
+    /* `gl.CONSTANT_COLOR` */
+    "constant color" |
+    /* `gl.ONE_MINUS_CONSTANT_COLOR` */
+    "one minus constant color" |
+    /* `gl.CONSTANT_ALPHA` */
+    "constant alpha" |
+    /* `gl.ONE_MINUS_CONSTANT_ALPHA` */
+    "one minus constant alpha" |
+    /* `gl.SRC_ALPHA_SATURATE` */
+    "src alpha saturate";
+
+  interface StencilOptions {
+    /* Toggles `gl.enable(gl.STENCIL_TEST)`. Default: false */
+    enable?: boolean;
+    /* Sets `gl.stencilMask`. Default: -1 */
+    mask?: number;
+    /* Sets `gl.stencilFunc`. Default: { cmp: 'always', ref: 0, mask: -1 } */
+    func?: REGL.StencilFunction;
+    /**
+     * Sets `gl.stencilOpSeparate` for front face.
+     * Default: { fail: 'keep', zfail: 'keep', zpass: 'keep' }
+     */
+    opFront?: REGL.StencilOperation;
+    /**
+     * Sets `gl.stencilOpSeparate` for back face.
+     * Default: { fail: 'keep', zfail: 'keep', zpass: 'keep' }
+     */
+    opBack?: REGL.StencilOperation;
+    /* Sets opFront and opBack simultaneously (`gl.stencilOp`). */
+    op?: REGL.StencilOperation;
+  }
+
+  interface StencilFunction {
+    /* comparison function */
+    cmp: REGL.ComparisonOperatorType;
+    /* reference value */
+    ref: number;
+    /* comparison mask */
+    mask: number;
+  }
+
+  interface StencilOperation {
+    /* The stencil operation applied when the stencil test fails. */
+    fail: REGL.StencilOperationType;
+    /* The stencil operation applied when the stencil test passes and the depth test fails. */
+    zfail: REGL.StencilOperationType;
+    /* The stencil operation applied when when both stencil and depth tests pass. */
+    zpass: REGL.StencilOperationType;
+  }
+
+  type StencilOperationType =
+    /* `gl.ZERO` */
+    "zero" |
+    /* `gl.KEEP` */
+    "keep" |
+    /* `gl.REPLACE` */
+    "replace" |
+    /* `gl.INVERT` */
+    "invert" |
+    /* `gl.INCR` */
+    "increment" |
+    /* `gl.DECR` */
+    "decrement" |
+    /* `gl.INCR_WRAP` */
+    "increment wrap" |
+    /* `gl.DECR_WRAP` */
+    "decrement wrap";
+
+  interface PolygonOffsetOptions {
+    /* Toggles `gl.enable(gl.POLYGON_OFFSET_FILL)`. Default: false */
+    enable?: boolean;
+    /* Sets `gl.polygonOffset`. Default: { factor: 0, units: 0 } */
+    offset?: REGL.PolygonOffset;
+  }
+
+  interface PolygonOffset {
+    factor: number;
+    units: number;
+  }
+
+  interface CullingOptions {
+    /* Toggles `gl.enable(gl.CULL_FACE)`. Default: false */
+    enable?: boolean;
+    /* Sets `gl.cullFace`. Default: 'back' */
+    face?: REGL.FaceOrientationType;
+  }
+
+  type FaceOrientationType =
+    /* `gl.FRONT` */
+    "front" |
+    /* `gl.BACK` */
+    "back";
+
+  type FaceWindingType =
+    /* `gl.CW` */
+    "cw" |
+    /* `gl.CCW` */
+    "ccw";
+
+  interface SamplingOptions {
+    /** Toggles `gl.enable(gl.SAMPLE_COVERAGE)`. Default: false */
+    enable?: boolean;
+    /** Toggles `gl.enable(gl.SAMPLE_ALPHA_TO_COVERAGE)`. Default: false */
+    alpha?: boolean;
+    /** Sets `gl.sampleCoverage`. Default: { value: 1, invert: false } */
+    coverage?: REGL.SampleCoverage;
+  }
+
+  interface SampleCoverage {
+    value: number;
+    invert: boolean;
+  }
+
+  interface ScissorOptions {
+    /* Toggles gl.enable(gl.SCISSOR). Default: false */
+    enable?: boolean;
+    /* Sets `gl.SCISSOR`. Default: {} */
+    box?: REGL.BoundingBox;
+  }
+
+  interface BoundingBox {
+    /* left coordinate of the box; Default: 0 */
+    x?: number;
+    /* top coordiante of the box; Default: 0 */
+    y?: number;
+    /* width of the box; Default: framebuffer width - `x` */
+    width?: number;
+    /* height of the box; Default: framebuffer height - `y` */
+    height?: number;
+  }
+
+  /*
+   * Resources
+   */
+
+  /**
+   * A *resource* is a handle to a GPU resident object, like a texture, FBO or buffer.
+   */
+  interface Resource {
+    /**
+     * relevant WebGL APIs:
+     * - `gl.deleteBuffer`
+     * - `gl.deleteTexture`
+     * - `gl.deleteRenderbuffer`
+     * - `gl.deleteFramebuffer`
+     */
+    destroy(): void;
+  }
+
+  interface Buffer extends REGL.Resource {
+    /**
+     * Wraps a WebGL array buffer object.
+     */
+    readonly stats: {
+      /** The size of the buffer in bytes. */
+      size: number;
+    }
+
+    /**
+     * Reinitializes the buffer with the new content.
+     * Relevant WebGL API: `gl.bufferData`
+     */
+    (data: REGL.BufferData): REGL.Buffer;
+    (options: REGL.BufferOptions): REGL.Buffer;
+
+    /**
+     * Update a portion of the buffer, optionally starting at byte offset `offset`.
+     * Relevant WebGL API: `gl.bufferSubData`
+     */
+    subdata(data: REGL.BufferData, offset?: number): REGL.Buffer;
+    subdata(options: REGL.BufferOptions, offset?: number): REGL.Buffer;
+  }
+
+  interface BufferOptions {
+    /** The data for the vertex buffer. Default: null */
+    data?: REGL.BufferData | null;
+    /** If `data` is `null` or not present reserves space for the buffer. Default: 0 */
+    length?: number;
+    /** Sets array buffer usage hint. Default: 'static' */
+    usage?: REGL.BufferUsageHint;
+    /** Data type for vertex buffer. Default: 'uint8' */
+    type?: REGL.BufferDataType;
+  }
+
+  type BufferData =
+    number[] |
+    number[][] |
+    Uint8Array |
+    Int8Array |
+    Uint16Array |
+    Int16Array |
+    Uint32Array |
+    Int32Array |
+    Float32Array;
+
+  type BufferUsageHint =
+    /** gl.DRAW_STATIC */
+    "static" |
+    /** gl.DYNAMIC_DRAW */
+    "dynamic" |
+    /** gl.STREAM_DRAW */
+    "stream";
+
+  type BufferDataType =
+    /** gl.UNSIGNED_BYTE */
+    "uint8" |
+    /** gl.BYTE */
+    "int8" |
+    /** gl.UNSIGNED_SHORT */
+    "uint16" |
+    /** gl.SHORT */
+    "int16" |
+    /** gl.UNSIGNED_INT */
+    "uint32" |
+    /** gl.INT */
+    "int32" |
+    /** gl.FLOAT */
+    "float32" | "float";
+
+  interface Elements extends REGL.Resource {
+    /**
+     * Wraps a WebGL element array buffer object.
+     */
+
+    /**
+     * Reinitializes the element buffer with the new content.
+     * Relevant WebGL API: `gl.bufferData`
+     */
+    (data: REGL.ElementsData): REGL.Elements;
+    (options: REGL.ElementsOptions): REGL.Elements;
+
+    /**
+     * Update a portion of the element buffer, optionally starting at byte offset `offset`.
+     * Relevant WebGL API: `gl.bufferSubData`
+     */
+    subdata(data: REGL.ElementsData, offset?: number): REGL.Elements;
+    subdata(options: REGL.ElementsOptions, offset?: number): REGL.Elements;
+  }
+
+  interface ElementsOptions {
+    /** The data of the element buffer. (Default: null) */
+    data?: REGL.ElementsData | null;
+    /** Usage hint (see gl.bufferData). (Default: 'static') */
+    usage?: REGL.BufferUsageHint;
+    /** Length of the element buffer in bytes. (Default: 0, or inferred from `data`) */
+    length?: number;
+    /** Default primitive type for element buffer. (Default: 0, or inferred from `data`) */
+    primitive?: REGL.PrimitiveType;
+    /** Data type for element buffer. (Default: 'uint8') */
+    type?: REGL.ElementsDataType;
+    /** Vertex count for element buffer. (Default: 0, or inferred from `data`) */
+    count?: number;
+  }
+
+  type ElementsData =
+    number[] |
+    number[][] |
+    Uint8Array |
+    Uint16Array |
+    Uint32Array;
+
+  type ElementsDataType =
+    "uint8" |
+    "uint16" |
+    "uint32";
+
+  interface Texture extends Resource {
+    readonly stats: {
+        /** Size of the texture in bytes. */
+        size: number;
+    }
+
+    /** Width of texture. */
+    readonly width: number;
+    /** Height of texture. */
+    readonly height: number;
+    /** Texture format. */
+    readonly format: REGL.TextureFormatType;
+    /** Texture data type. */
+    readonly type: REGL.TextureDataType;
+    /** Texture magnification filter. */
+    readonly mag: REGL.TextureMagFilterType;
+    /** Texture minification filter. */
+    readonly min: REGL.TextureMinFilterType;
+    /** Texture wrap mode on S axis. */
+    readonly wrapS: REGL.TextureWrapModeType;
+    /** Texture wrap mode on T axis. */
+    readonly wrapT: REGL.TextureWrapModeType;
+  }
+
+  type TextureFormatType =
+    /* `gl.ALPHA`; channels: 1; types: 'uint8', 'half float', 'float' */
+    "alpha" |
+    /* `gl.LUMINANCE`; channels: 1; types: 'uint8', 'half float', 'float' */
+    "luminance" |
+    /* `gl.LUMINANCE_ALPHA`; channels: 2; types: 'uint8', 'half float', 'float' */
+    "luminance alpha" |
+    /* `gl.RGB`; channels: 3; types: 'uint8', 'half float', 'float' */
+    "rgb" |
+    /* `gl.RGBA`; channels: 4; types: 'uint8', 'half float', 'float' */
+    "rgba" |
+    /* `gl.RGBA4`; channels: 4; types: 'rgba4' */
+    "rgba4" |
+    /* `gl.RGB5_A1`; channels: 4; types: 'rgba5 a1' */
+    "rgb5 a1" |
+    /* `gl.RGB565`; channels: 3; types: 'rgb565' */
+    "rgb565" |
+    /* `ext.SRGB`; channels: 3; types: 'uint8', 'half float', 'float' */
+    "srgb" |
+    /* `ext.RGBA`; channels: 4; types: 'uint8', 'half float', 'float' */
+    "srgba" |
+    /* `gl.DEPTH_COMPONENT`; channels: 1; types: 'uint16', 'uint32' */
+    "depth" |
+    /* `gl.DEPTH_STENCIL`; channels: 2; 'depth stencil' */
+    "depth stencil" |
+    /* `ext.COMPRESSED_RGB_S3TC_DXT1_EXT`; channels: 3; types: 'uint8' */
+    "rgb s3tc dxt1" |
+    /* `ext.COMPRESSED_RGBA_S3TC_DXT1_EXT`; channels: 4; types: 'uint8' */
+    "rgba s3tc dxt1" |
+    /* `ext.COMPRESSED_RGBA_S3TC_DXT3_EXT`; channels: 4; types: 'uint8' */
+    "rgba s3tc dxt3" |
+    /* `ext.COMPRESSED_RGBA_S3TC_DXT5_EXT`; channels: 4; types: 'uint8' */
+    "rgba s3tc dxt5" |
+    /* `ext.COMPRESSED_RGB_ATC_WEBGL`; channels: 3; types: 'uint8' */
+    "rgb atc" |
+    /* `ext.COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL`; channels: 4; types: 'uint8' */
+    "rgba atc explicit alpha" |
+    /* `ext.COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL`; channels: 4; types: 'uint8' */
+    "rgba atc interpolated alpha" |
+    /* `ext.COMPRESSED_RGB_PVRTC_4BPPV1_IMG`; channels: 3; types: 'uint8' */
+    "rgb pvrtc 4bppv1" |
+    /* `ext.COMPRESSED_RGB_PVRTC_2BPPV1_IMG`; channels: 3; types: 'uint8' */
+    "rgb pvrtc 2bppv1" |
+    /* `ext.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG`; channels: 4; types: 'uint8' */
+    "rgba pvrtc 4bppv1" |
+    /* `ext.COMPRESSED_RGBA_PVRTC_2BPPV1_IMG`; channels: 4; types: 'uint8' */
+    "rgba pvrtc 2bppv1" |
+    /* `ext.COMPRESSED_RGB_ETC1_WEBGL`; channels: 3; types: 'uint8' */
+    "rgb etc1";
+
+  type TextureDataType =
+    /* `gl.UNSIGNED_BYTE` */
+    "uint8" |
+    /* `gl.UNSIGNED_SHORT` */
+    "uint16" |
+    /* `gl.UNSIGNED_INT` */
+    "uint32" |
+    /* `gl.FLOAT` */
+    "float" | "float32" |
+    /* `ext.HALF_FLOAT_OES` */
+    "half float" | "float16";
+
+  /* Related WebGL API: `gl.MAG_FILTER` */
+  type TextureMagFilterType =
+    /* `gl.NEAREST` */
+    "nearest" |
+    /* `gl.LINEAR` */
+    "linear";
+
+  /* Related WebGL API: `gl.MIN_FILTER` */
+  type TextureMinFilterType =
+    /* `gl.NEAREST` */
+    "nearest" |
+    /* `gl.LINEAR` */
+    "linear" |
+    /* `gl.LINEAR_MIPMAP_LINEAR` */
+    "linear mipmap linear" | "mipmap" |
+    /* `gl.NEAREST_MIPMAP_LINEAR` */
+    "nearest mipmap linear" |
+    /* `gl.LINEAR_MIPMAP_NEAREST` */
+    "linear mipmap nearest" |
+    /* `gl.NEAREST_MIPMAP_NEAREST` */
+    "nearest mipmap nearest";
+
+  type TextureWrapModeType =
+    /* `gl.REPEAT` */
+    "repeat" |
+    /* `gl.CLAMP_TO_EDGE` */
+    "clamp" |
+    /* `gl.MIRRORED_REPEAT` */
+    "mirror";
+
+  interface Texture2D extends Texture {
+    /* Reinitializes the texture in place with dimensions 1 x 1. */
+    (): REGL.Texture2D;
+    /* Reinitializes the texture in place with dimensions `radius` x `radius`. */
+    (radius: number): REGL.Texture2D;
+    /* Reinitializes the texture in place with dimensions `width` x `height`. */
+    (width: number, height: number): REGL.Texture2D;
+    /* Reinitializes the texture in place using the provided `data`. */
+    (data: REGL.TextureImageData): REGL.Texture2D;
+    /* Reinitializes the texture in place using creation `options`. */
+    (options: REGL.Texture2DOptions): REGL.Texture2D;
+
+    /**
+     * Replaces the part of texture with new data.
+     *
+     * @param data      image data object, similar to arguments for the texture constructor
+     * @param x         horizontal offset of the image within the texture (Default: `0`)
+     * @param y         vertical offset of the image within the texture (Default: `0`)
+     * @param level     mipmap level of the texture to modify (Default: `0`)
+     */
+    /* Replaces the area at offset `x` (default: 0), `y` (default: 0), with `data`. */
+    subimage(data: REGL.TextureImageData, x?: number, y?: number, level?: number): REGL.Texture2D;
+    /* Replaces a subset of the image using creation `options`. */
+    subimage(options: Texture2DOptions): REGL.Texture2D;
+
+    /** Resizes the texture to `radius` x `radius`. */
+    resize(radius: number): REGL.Texture2D;
+    /** Resizes the texture to dimensions `width` x `height`. */
+    resize(width: number, height: number): REGL.Texture2D;
+  }
+
+  interface Texture2DOptions {
+    /* Sets `width`, `height` and, optionally, `channels`. */
+    shape?: [number, number] | [number, number, REGL.TextureChannelsType];
+    /* Sets both width and height to the same value. */
+    radius?: number;
+    /* Width of texture. Default: 0 */
+    width?: number;
+    /* Height of texture. Default: 0 */
+    height?: number;
+    /**
+     * Sets the number of color channels for the texture format.
+     * It can be used as an alternative to `format`.
+     * Default: null
+     */
+    channels?: REGL.TextureChannelsType | null;
+    /**
+     * The following properties, `data` and `copy` are mutually exclusive.
+     */
+    /* Image data for the texture. Default: null */
+    data?: REGL.TextureImageData | null;
+    /* Create texture by copying the pixels in the current frame buffer. Default: false */
+    copy?: boolean;
+
+    /* Sets magnification filter. Default: 'nearest' */
+    mag?: REGL.TextureMagFilterType;
+    /* Sets minification filter. Default: 'nearest' */
+    min?: REGL.TextureMinFilterType;
+    /* Sets wrap mode for both axes, either to the same value, or independently, `[wrapS, wrapT]` */
+    wrap?: REGL.TextureWrapModeType | [REGL.TextureWrapModeType, REGL.TextureWrapModeType];
+    /* Sets wrap mode on S axis. Default: 'clamp' */
+    wrapS?: REGL.TextureWrapModeType;
+    /* Sets wrap mode on T axis. Default: 'clamp' */
+    wrapT?: REGL.TextureWrapModeType;
+    /* Sets number of anisotropic samples; requires `EXT_texture_filter_anisotropic`. Default: 0 */
+    aniso?: number;
+    /* Determines the format of the texture and possibly also the type. Default: 'rgba' */
+    format?: REGL.TextureFormatType;
+    /**
+     * Texture type.
+     * In many cases type can be inferred from the format and other information in the texture.
+     * However, in some situations it may still be necessary to set it manually.
+     * Default: 'uint8'
+     */
+    type?: REGL.TextureDataType;
+
+    /**
+     * If boolean, then it sets whether or not we should regenerate the mipmaps.
+     *
+     * If a string, it allows you to specify a hint to the mipmap generator.
+     * If a hint is specified, then also the mipmaps will be regenerated.
+     *
+     * Finally, mipmap can also be an array of arrays. In this case, every subarray will be one of
+     * the mipmaps, and you can thus use this option to manually specify the mipmaps of the image.
+     *
+     * Default: false
+     */
+    mipmap?: boolean | REGL.TextureMipmapHintType | number[][];
+    /* Flips textures vertically when uploading. Default: false */
+    flipY?: boolean;
+    /* Sets unpack alignment per row. Default: 1 */
+    alignment?: REGL.TextureUnpackAlignmentType;
+    /* Premultiply alpha when unpacking. Default: false */
+    premultiplyAlpha?: boolean;
+    /* Sets the WebGL color space flag for pixel unpacking. Default: 'none' */
+    colorSpace?: REGL.TextureColorSpaceType;
+  }
+
+  type TextureImageData =
+    number[] |
+    number[][] |
+    number[][][] |
+    ArrayBufferView |
+    REGL.NDArrayLike |
+    HTMLImageElement |
+    HTMLVideoElement |
+    HTMLCanvasElement |
+    CanvasRenderingContext2D;
+
+  /**
+   * An N-dimensional array, as per `scijs/ndarray`.
+   */
+  interface NDArrayLike {
+    shape: number[];
+    stride: number[];
+    offset: number;
+    data: number[] | ArrayBufferView;
+  }
+
+  type TextureMipmapHintType =
+    /* `gl.DONT_CARE` */
+    "don't care" | "dont care" |
+    /* `gl.NICEST` */
+    "nice" |
+    /* `gl.FASTEST` */
+    "fast";
+
+  type TextureColorSpaceType =
+    /* `gl.NONE` */
+    "none" |
+    /* gl.BROWSER_DEFAULT_WEBGL` */
+    "browser";
+
+  type TextureChannelsType = 1 | 2 | 3 | 4;
+
+  /* Related WebGL API: `gl.pixelStorei` */
+  type TextureUnpackAlignmentType =
+    /* byte-alignment */
+    1 |
+    /* rows aligned to even-numbered bytes */
+    2 |
+    /* word-alignment */
+    4 |
+    /* rows start on double-word boundaries */
+    8;
+
+  interface TextureCube extends Texture {
+    /* Reinitializes the texture in place with faces of dimensions 1 x 1. */
+    (): REGL.TextureCube;
+    /* Reinitializes the texture in place with faces of dimensions `radius` x `radius`. */
+    (radius: number): REGL.TextureCube;
+    /* Reinitializes the texture in place using the provided image data for the six faces. */
+    (
+      posXData: REGL.TextureImageData, negXData: REGL.TextureImageData,
+      posYData: REGL.TextureImageData, negYData: REGL.TextureImageData,
+      posZData: REGL.TextureImageData, negZData: REGL.TextureImageData
+    ): REGL.TextureCube;
+    /* Reinitializes the texture in place using the provided creation options for the six faces. */
+    (
+      posXOptions: REGL.Texture2DOptions, negXOptions: REGL.Texture2DOptions,
+      posYOptions: REGL.Texture2DOptions, negYOptions: REGL.Texture2DOptions,
+      posZOptions: REGL.Texture2DOptions, negZOptions: REGL.Texture2DOptions,
+    ): REGL.TextureCube;
+    /* Reinitializes the texture in place using creation `options`. */
+    (options: REGL.TextureCubeOptions): REGL.TextureCube;
+
+    /**
+     * Replaces the part of texture with new data.
+     *
+     * @param face      index of the face to modify
+     * @param data      2D image data object to use for the replacement
+     * @param x         horizontal offset of the image within the face (Default: `0`)
+     * @param y         vertical offset of the image within the face (Default: `0`)
+     * @param level     mipmap level of the texture to modify (Default: `0`)
+     */
+    subimage(
+      face: REGL.TextureCubeFaceIndex,
+      data: TextureImageData,
+      x?: number,
+      y?: number,
+      level?: number,
+    ): REGL.TextureCube;
+
+    /** Resizes the cube-map texture, setting the dimensions of each face to `radius` x `radius`. */
+    resize(radius: number): REGL.TextureCube;
+  }
+
+  type TextureCubeFaceIndex =
+    /* positive X face */
+    0 |
+    /* negative X face */
+    1 |
+    /* positive Y face */
+    2 |
+    /* negative Y face */
+    3 |
+    /* positive Z face */
+    4 |
+    /* negative Z face */
+    5;
+
+  interface TextureCubeOptions extends Texture2DOptions {
+    /* Uses the provided texture data for the six faces. */
+    faces?: [
+      TextureImageData, TextureImageData,
+      TextureImageData, TextureImageData,
+      TextureImageData, TextureImageData
+    ];
+  }
+
+  interface Renderbuffer extends REGL.Resource {
+    readonly stats: {
+        /** Size of the renderbuffer in bytes. */
+        size: number;
+    }
+
+    /** Width of the renderbuffer */
+    readonly width: number;
+    /** Height of the renderbuffer */
+    readonly height: number;
+    /** Format of the renderbuffer. */
+    readonly format: number;
+
+    /* Reinitializes the Renderbuffer in place using dimensions: 1 x 1. */
+    (): REGL.Renderbuffer;
+    /* Reinitializes the Renderbuffer in place using dimensions: `radius` x `radius`. */
+    (radius: number): REGL.Renderbuffer;
+    /* Reinitializes the Renderbuffer in place using dimensions: `width` x `height`. */
+    (width: number, height: number): REGL.Renderbuffer;
+    /* Reinitializes the Renderbuffer in place using creation `options`. */
+    (options: REGL.RenderbufferOptions): REGL.Renderbuffer;
+
+    /* Resizes the Renderbuffer. */
+    resize(radius: number): REGL.Renderbuffer;
+    resize(width: number, height: number): REGL.Renderbuffer;
+  }
+
+  interface RenderbufferOptions {
+    /* NB: `shape`, `radius`, and `width`/`height` are alternative (and mutually exclusive) means for setting the size of the renderbuffer. */
+    /* Sets the dimensions [width, height] for the renderbuffer. */
+    shape?: [number, number];
+    /* Sets the dimensions `radius` x `radius` for the renderbuffer. */
+    radius?: number;
+    /* Sets the width of the renderbuffer. Default: `gl.drawingBufferWidth` */
+    width?: number;
+    /* Sets the height of the renderbuffer. Default: `gl.drawingBufferHeight` */
+    height?: number;
+    /** Sets the internal format of the render buffer. Default 'rgba4' */
+    format?: REGL.RenderbufferFormat;
+  }
+
+  type RenderbufferFormat =
+    REGL.RenderbufferColorFormat |
+    /* `gl.DEPTH_COMPONENT16` */
+    "depth" |
+    /* `gl.STENCIL_INDEX8` */
+    "stencil" |
+    /* `gl.DEPTH_STENCIL` */
+    "depth stencil";
+
+  type RenderbufferColorFormat =
+    /* `gl.RGBA4` */
+    "rgba4" |
+    /* `gl.RGB565` */
+    "rgb565" |
+    /* `gl.RGB5_A1` */
+    "rgb5 a1" |
+    /* `gl.RGB16F`, requires EXT_color_buffer_half_float */
+    "rgb16f" |
+    /* `gl.RGBA16F`, requires EXT_color_buffer_half_float */
+    "rgba16f" |
+    /* `gl.RGBA32F`, requires WEBGL_color_buffer_float */
+    "rgba32f" |
+    /* `gl.SRGB8_ALPHA8`, requires EXT_sRGB */
+    "srgba";
+
+  type Framebuffer = REGL.Framebuffer2D | REGL.FramebufferCube;
+
+  interface Framebuffer2D extends REGL.Resource {
+    /* Reinitializes the Framebuffer in place using dimensions: 1 x 1. */
+    (): REGL.Framebuffer2D;
+    /* Reinitializes the Framebuffer in place using dimensions: `radius` x `radius`. */
+    (radius: number): REGL.Framebuffer2D;
+    /* Reinitializes the Framebuffer in place using dimensions: `width` x `height`. */
+    (width: number, height: number): REGL.Framebuffer2D;
+    /* Reinitializes the Framebuffer in place using creation `options`. */
+    (options: REGL.FramebufferOptions): REGL.Framebuffer2D;
+
+    /* Framebuffer binding */
+
+    /* Binds a framebuffer directly. This is a short cut for creating a command which sets the framebuffer. */
+    use<
+      Context extends REGL.DefaultContext = REGL.DefaultContext,
+      Props extends {} = {}
+    >(body: REGL.CommandBodyFn<Context, Props>): void;
+
+    /* Resizes the Framebuffer and all its attachments. */
+    resize(radius: number): REGL.Framebuffer2D;
+    resize(width: number, height: number): REGL.Framebuffer2D;
+  }
+
+  interface FramebufferOptions {
+    /* NB: `shape`, `radius`, and `width`/`height` are alternative (and mutually exclusive) means for setting the size of the framebuffer. */
+    /* Sets the dimensions [width, height] for the framebuffer. */
+    shape?: [number, number];
+    /* Sets the dimensions `radius` x `radius` for the framebuffer. */
+    radius?: number;
+    /* Sets the width of the framebuffer. Default: `gl.drawingBufferWidth` */
+    width?: number;
+    /* Sets the height of the framebuffer. Default: `gl.drawingBufferHeight` */
+    height?: number;
+
+    /* NB: If neither `color` nor `colors` is specified, color attachments are created automatically. */
+    /* A texture or renderbuffer for the color attachment. */
+    color?: REGL.Framebuffer2DAttachment;
+    /* An array of textures or renderbuffers for the color attachments. */
+    colors?: REGL.Framebuffer2DAttachment[];
+    /* Sets the format of the color buffer. Ignored if `color` is specified. Default: 'rgba' */
+    colorFormat?: REGL.FramebufferTextureColorFormat | REGL.RenderbufferColorFormat;
+    /* Sets the type of the color buffer if it is a texture. Default: 'uint8' */
+    colorType?: REGL.FramebufferColorDataType;
+    /* Sets the number of color buffers. Values > 1 require WEBGL_draw_buffers. Default: 1 */
+    colorCount?: number;
+    /* If boolean, toggles the depth attachment. If a renderbuffer or texture, sets the depth attachment. Default: true */
+    depth?: boolean | REGL.Framebuffer2DAttachment;
+    /* If boolean, toggles the stencil attachments. If a renderbuffer or texture, sets the stencil attachment.  Default: true */
+    stencil?: boolean | REGL.Framebuffer2DAttachment;
+    /* If boolean, toggles both the depth and stencil attachments. If a renderbuffer or texture, sets the combined depth/stencil attachment. Default: true */
+    depthStencil?: boolean | REGL.Framebuffer2DAttachment;
+    /* Toggles whether depth/stencil attachments should be in texture. Requires WEBGL_depth_texture. Default: false */
+    depthTexture?: boolean;
+  }
+
+  type Framebuffer2DAttachment = REGL.Texture2D | REGL.Renderbuffer;
+
+  interface FramebufferCube extends REGL.Resource {
+    /* Reinitializes the FramebufferCube in place using face dimensions 1 x 1. */
+    (): REGL.FramebufferCube;
+    /* Reinitializes the FramebufferCube in place using face dimensions `radius` x `radius`. */
+    (radius: number): REGL.FramebufferCube;
+    /* Reinitializes the FramebufferCube in place using creation `options`. */
+    (options: FramebufferCubeOptions): REGL.FramebufferCube;
+
+    /* Resizes the FramebufferCube and all its attachments. */
+    resize(radius: number): REGL.FramebufferCube;
+  }
+
+  interface FramebufferCubeOptions {
+    /* NB: `shape`, `radius`, and `width`/`height` are alternative (and mutually exclusive) means for setting the size of the cube. */
+    /* Sets the dimensions [width, height] for each face of the cube. Width must equal height. */
+    shape?: [number, number];
+    /* Sets the dimensions `radius` x `radius` for each face of the cube. */
+    radius?: number;
+    /* Sets the width dimension for each face of the cube. Must equal `height`. */
+    width?: number;
+    /* Sets the height dimension for each face of the cube. Must equal `width`. */
+    height?: number;
+
+    /* A TextureCube for the color attachment. */
+    color?: REGL.TextureCube;
+    /* An array of TextureCubes for the color attachments. */
+    colors?: REGL.TextureCube[];
+    /* Sets the format of the color buffer. */
+    colorFormat?: REGL.FramebufferTextureColorFormat;
+    /* Sets the type of the color buffer. */
+    colorType?: REGL.FramebufferColorDataType;
+    /* Sets the number of color buffers. Values > 1 require WEBGL_draw_buffers. Default: 1 */
+    colorCount?: number;
+    /* If boolean, toggles the depth attachment. If texture, sets the depth attachment. Default: true */
+    depth?: boolean | REGL.TextureCube;
+    /* If boolean, toggles the stencil attachment. If texture, sets the stencil attachment. Default: true */
+    stencil?: boolean | REGL.TextureCube;
+    /* If boolean, toggles both the depth and stencil attachments. If texture, sets the combined depth/stencil attachment. Default: true */
+    depthStencil?: boolean | REGL.TextureCube;
+  }
+
+  /* `gl.RGBA` */
+  type FramebufferTextureColorFormat = "rgba";
+
+  type FramebufferColorDataType =
+    /* `gl.UNSIGNED_BYTE` */
+    "uint8" |
+    /* `ext.HALF_FLOAT_OES` (16-bit float), requires OES_texture_half_float */
+    "half float" |
+    /* `gl.FLOAT` (32-bit float), requires OES_texture_float */
+    "float";
+
+  interface Limits {
+    /** An array of bits depths for the red, green, blue and alpha channels */
+    colorBits: [number, number, number, number];
+    /** Bit depth of drawing buffer */
+    depthBits: number;
+    /** Bit depth of stencil buffer */
+    stencilBits: number;
+    /** gl.SUBPIXEL_BITS */
+    subpixelBits: number;
+    /** A list of all supported extensions */
+    extensions: string[];
+    /** Maximum number of anisotropic filtering samples */
+    maxAnisotropic: number;
+    /** Maximum number of draw buffers */
+    maxDrawbuffers: number;
+    /** Maximum number of color attachments */
+    maxColorAttachments: number;
+    /** gl.ALIASED_POINT_SIZE_RANGE */
+    pointSizeDims: Float32Array;
+    /** gl.ALIASED_LINE_WIDTH_RANGE */
+    lineWidthDims: Float32Array;
+    /** gl.MAX_VIEWPORT_DIMS */
+    maxViewportDims: Int32Array;
+    /** gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS */
+    maxCombinedTextureUnits: number;
+    /** gl.MAX_CUBE_MAP_TEXTURE_SIZE */
+    maxCubeMapSize: number;
+    /** gl.MAX_RENDERBUFFER_SIZE */
+    maxRenderbufferSize: number;
+    /** gl.MAX_TEXTURE_IMAGE_UNITS */
+    maxTextureUnits: number;
+    /** gl.MAX_TEXTURE_SIZE */
+    maxTextureSize: number;
+    /** gl.MAX_VERTEX_ATTRIBS */
+    maxAttributes: number;
+    /** gl.MAX_VERTEX_UNIFORM_VECTORS */
+    maxVertexUniforms: number;
+    /** gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS */
+    maxVertexTextureUnits: number;
+    /** gl.MAX_VARYING_VECTORS */
+    maxVaryingVectors: number;
+    /** gl.MAX_FRAGMENT_UNIFORM_VECTORS */
+    maxFragmentUniforms: number;
+    /** gl.SHADING_LANGUAGE_VERSION */
+    glsl: string;
+    /** gl.RENDERER */
+    renderer: string;
+    /** gl.VENDOR */
+    vendor: string;
+    /** gl.VERSION */
+    version: string;
+    /** A list of all supported texture formats */
+    textureFormats: TextureFormatType[];
+  }
+
+  interface Stats {
+    /** The number of array buffers currently allocated */
+    bufferCount: number;
+    /** The number of element buffers currently allocated */
+    elementsCount: number;
+    /** The number of framebuffers currently allocated */
+    framebufferCount: number;
+    /** The number of shaders currently allocated */
+    shaderCount: number;
+    /** The number of textures currently allocated */
+    textureCount: number;
+    /** The number of cube maps currently allocated */
+    cubeCount: number;
+    /** The number of renderbuffers currently allocated */
+    renderbufferCount: number;
+    /** The maximum number of texture units used */
+    maxTextureUnits: number;
+
+    // The following functions are only available if regl is initialized with option `profile: true`
+
+    /** The total amount of memory allocated for textures and cube maps */
+    getTotalTextureSize?: () => number;
+    /** The total amount of memory allocated for array buffers and element buffers */
+    getTotalBufferSize?: () => number;
+    /** The total amount of memory allocated for renderbuffers */
+    getTotalRenderbufferSize?: () => number;
+    /** The maximum number of uniforms in any shader */
+    getMaxUniformsCount?: () => number;
+    /** The maximum number of attributes in any shader */
+    getMaxAttributesCount?: () => number;
+  }
+
+  interface CommandStats {
+    /** The number of times the command has been called. */
+    count: number;
+    /**
+     * The cumulative CPU time spent executing the command in milliseconds.
+     * `cpuTime` uses `performance.now` if available. Otherwise it falls back to `Date.now`.
+     */
+    cpuTime: number;
+    /**
+     * The cumulative GPU time spent executing the command in milliseconds.
+     * (requires the `EXT_disjoint_timer_query` extension).
+     * GPU timer queries update asynchronously. If you are not using `regl.frame()` to tick your
+     * application, then you should periodically call `regl.poll()` each frame to update the timer
+     * statistics.
+     */
+    gpuTime: number;
+  }
+
+  /**
+   * The following types are defined for the convenience of clients of this library. They represent
+   * the most likely forms in which values being passed to shaders (via uniforms and attributes) are
+   * defined: flat JS arrays for vectors and either flat or two-dimensional JS arrays for matrices.
+   */
+
+  type Vec2 = [number, number];
+  type Vec3 = [number, number, number];
+  type Vec4 = [number, number, number, number];
+
+  type BVec2 = [boolean, boolean];
+  type BVec3 = [boolean, boolean, boolean];
+  type BVec4 = [boolean, boolean, boolean, boolean];
+
+  type Mat2 = [
+    number, number,
+    number, number
+  ] | [
+    REGL.Vec2,
+    REGL.Vec2
+  ];
+
+  type Mat3 = [
+    number, number, number,
+    number, number, number,
+    number, number, number
+  ] | [
+    REGL.Vec3,
+    REGL.Vec3,
+    REGL.Vec3
+  ];
+
+  type Mat4 = [
+    number, number, number, number,
+    number, number, number, number,
+    number, number, number, number,
+    number, number, number, number
+  ] | [
+    REGL.Vec4,
+    REGL.Vec4,
+    REGL.Vec4,
+    REGL.Vec4
+  ];
+}

--- a/example/typescript/basic.ts
+++ b/example/typescript/basic.ts
@@ -1,0 +1,59 @@
+/*
+  tags: basic
+
+  <p> This example is a simple demonstration of how to use regl to draw a triangle. </p>
+ */
+
+// The default method exposed by the module wraps a canvas element
+import REGL = require('../../regl')
+const regl = REGL()
+
+// This clears the color buffer to black and the depth buffer to 1
+regl.clear({
+  color: [0, 0, 0, 1],
+  depth: 1
+})
+
+interface Uniforms {
+  color: REGL.Vec4;
+}
+
+interface Attributes {
+  position: REGL.Vec2[];
+}
+
+// In regl, draw operations are specified declaratively using. Each JSON
+// command is a complete description of all state. This removes the need to
+// .bind() things like buffers or shaders. All the boilerplate of setting up
+// and tearing down state is automated.
+regl<Uniforms, Attributes>({
+
+  // In a draw call, we can pass the shader source code to regl
+  frag: `
+  precision mediump float;
+  uniform vec4 color;
+  void main () {
+    gl_FragColor = color;
+  }`,
+
+  vert: `
+  precision mediump float;
+  attribute vec2 position;
+  void main () {
+    gl_Position = vec4(position, 0, 1);
+  }`,
+
+  attributes: {
+    position: [
+      [-1, 0],
+      [0, -1],
+      [1, 1]
+    ]
+  },
+
+  uniforms: {
+    color: [1, 0, 0, 1]
+  },
+
+  count: 3
+})()

--- a/example/typescript/batch.ts
+++ b/example/typescript/batch.ts
@@ -1,0 +1,92 @@
+/*
+  tags: basic
+
+  <p>This example demonstrates how to use batch mode commands</p>
+
+<p> To use a command in batch mode, we pass in an array of objects.  Then
+ the command is executed once for each object in the array. </p>
+*/
+
+// As usual, we start by creating a full screen regl object
+import REGL = require('../../regl')
+const regl = REGL()
+
+interface Props {
+  offset: REGL.Vec2;
+}
+
+interface Uniforms {
+  color: REGL.Vec4;
+  angle: number;
+  offset: REGL.Vec2;
+}
+
+interface Attributes {
+  position: number[];
+}
+
+// Next we create our command
+const draw = regl<Uniforms, Attributes, Props>({
+  frag: `
+    precision mediump float;
+    uniform vec4 color;
+    void main() {
+      gl_FragColor = color;
+    }`,
+
+  vert: `
+    precision mediump float;
+    attribute vec2 position;
+    uniform float angle;
+    uniform vec2 offset;
+    void main() {
+      gl_Position = vec4(
+        cos(angle) * position.x + sin(angle) * position.y + offset.x,
+        -sin(angle) * position.x + cos(angle) * position.y + offset.y, 0, 1);
+    }`,
+
+  attributes: {
+    position: [
+      0.5, 0,
+      0, 0.5,
+      1, 1]
+  },
+
+  uniforms: {
+    // the batchId parameter gives the index of the command
+    color: ({tick}, props, batchId) => [
+      Math.sin(0.02 * ((0.1 + Math.sin(batchId)) * tick + 3.0 * batchId)),
+      Math.cos(0.02 * (0.02 * tick + 0.1 * batchId)),
+      Math.sin(0.02 * ((0.3 + Math.cos(2.0 * batchId)) * tick + 0.8 * batchId)),
+      1
+    ],
+    angle: ({tick}) => 0.01 * tick,
+    offset: regl.prop<Props, 'offset'>('offset')
+  },
+
+  depth: {
+    enable: false
+  },
+
+  count: 3
+})
+
+// Here we register a per-frame callback to draw the whole scene
+regl.frame(function () {
+  regl.clear({
+    color: [0, 0, 0, 1]
+  })
+
+  // This tells regl to execute the command once for each object
+  draw([
+    { offset: [-1, -1] },
+    { offset: [-1, 0] },
+    { offset: [-1, 1] },
+    { offset: [0, -1] },
+    { offset: [0, 0] },
+    { offset: [0, 1] },
+    { offset: [1, -1] },
+    { offset: [1, 0] },
+    { offset: [1, 1] }
+  ])
+})

--- a/example/typescript/bunny.ts
+++ b/example/typescript/bunny.ts
@@ -1,0 +1,70 @@
+/*
+  tags: basic
+
+  <p> This example shows how to draw a mesh with regl </p>
+*/
+import REGL = require('../../regl')
+import mat4 = require('gl-mat4')
+import bunny = require('bunny')
+
+const regl = REGL()
+
+interface Uniforms {
+  model: REGL.Mat4;
+  view: REGL.Mat4;
+  projection: REGL.Mat4;
+}
+
+interface Attributes {
+  position: REGL.Vec3;
+}
+
+const drawBunny = regl<Uniforms, Attributes>({
+  vert: `
+  precision mediump float;
+  attribute vec3 position;
+  uniform mat4 model, view, projection;
+  void main() {
+    gl_Position = projection * view * model * vec4(position, 1);
+  }`,
+
+  frag: `
+  precision mediump float;
+  void main() {
+    gl_FragColor = vec4(1, 1, 1, 1);
+  }`,
+
+  // this converts the vertices of the mesh into the position attribute
+  attributes: {
+    position: bunny.positions
+  },
+
+  // and this converts the faces fo the mesh into elements
+  elements: bunny.cells,
+
+  uniforms: {
+    model: mat4.identity([]),
+    view: ({tick}) => {
+      const t = 0.01 * tick
+      return mat4.lookAt([],
+        [30 * Math.cos(t), 2.5, 30 * Math.sin(t)],
+        [0, 2.5, 0],
+        [0, 1, 0])
+    },
+    projection: ({viewportWidth, viewportHeight}) =>
+      mat4.perspective([],
+        Math.PI / 4,
+        viewportWidth / viewportHeight,
+        0.01,
+        1000)
+  }
+})
+
+regl.frame(() => {
+  regl.clear({
+    depth: 1,
+    color: [0, 0, 0, 1]
+  })
+
+  drawBunny()
+})

--- a/example/typescript/camera.ts
+++ b/example/typescript/camera.ts
@@ -1,0 +1,58 @@
+/*
+  tags: basic
+
+  <p>This example shows how to implement a movable camera with regl.</p>
+ */
+
+import REGL = require('../../regl')
+const regl = REGL()
+
+import bunny = require('bunny')
+import normals = require('angle-normals')
+
+import createCamera = require('../util/camera')
+const camera = createCamera(regl, {
+  center: [0, 2.5, 0]
+})
+
+interface Uniforms {
+  projection: REGL.Mat4;
+  view: REGL.Mat4;
+}
+
+interface Attributes {
+  position: REGL.Vec3[];
+  normal: REGL.Vec3[];
+}
+
+const drawBunny = regl<Uniforms, Attributes>({
+  frag: `
+    precision mediump float;
+    varying vec3 vnormal;
+    void main () {
+      gl_FragColor = vec4(abs(vnormal), 1.0);
+    }`,
+  vert: `
+    precision mediump float;
+    uniform mat4 projection, view;
+    attribute vec3 position, normal;
+    varying vec3 vnormal;
+    void main () {
+      vnormal = normal;
+      gl_Position = projection * view * vec4(position, 1.0);
+    }`,
+  attributes: {
+    position: bunny.positions,
+    normal: normals(bunny.cells, bunny.positions)
+  },
+  elements: bunny.cells
+})
+
+regl.frame(() => {
+  regl.clear({
+    color: [0, 0, 0, 1]
+  })
+  camera(() => {
+    drawBunny()
+  })
+})

--- a/example/typescript/dds.ts
+++ b/example/typescript/dds.ts
@@ -1,0 +1,137 @@
+/*
+  tags: advanced
+  <p>This example shows how you can parse dds files with resl.</p>
+ */
+
+import REGL = require('../../regl')
+const regl = REGL({
+  extensions: 'WEBGL_compressed_texture_s3tc'
+})
+import parseDDS = require('parse-dds')
+import resl = require('resl')
+
+interface DDS {
+  shape: [number, number];
+  flags: any;
+  format: 'dxt1' | 'dxt3' | 'dxt5';
+  images: Image[];
+  cubemap: boolean;
+}
+
+interface Image {
+  shape: [number, number];
+  offset: number;
+  length: number;
+}
+
+interface Assets {
+  diffuse: REGL.Texture2D;
+  normals: REGL.Texture2D;
+  specular: REGL.Texture2D;
+}
+
+interface Uniforms extends Assets {
+  lightPosition: REGL.Vec2;
+}
+
+interface Attributes {
+  position: number[];
+}
+
+resl({
+  manifest: {
+    diffuse: {
+      type: 'binary',
+      src: '../assets/alpine_cliff_a.dds',
+      parser: (data: ArrayBuffer) => {
+        const dds: DDS = parseDDS(data)
+        const image = dds.images[0]
+        return regl.texture({
+          format: ('rgba s3tc ' + dds.format) as REGL.TextureFormatType,
+          shape: dds.shape,
+          mag: 'linear',
+          data: new Uint8Array(data, image.offset, image.length)
+        })
+      }
+    },
+
+    specular: {
+      type: 'image',
+      src: '../assets/alpine_cliff_a_spec.png',
+      parser: (data: HTMLImageElement) => regl.texture({
+        mag: 'linear',
+        data: data
+      })
+    },
+
+    normals: {
+      type: 'image',
+      src: '../assets/alpine_cliff_a_norm.png',
+      parser: (data: HTMLImageElement) => regl.texture({
+        mag: 'linear',
+        data: data
+      })
+    }
+  },
+
+  onDone: ({ diffuse, specular, normals }: Assets) => {
+    const draw = regl<Uniforms, Attributes>({
+      frag: `
+      precision mediump float;
+      uniform sampler2D specular, normals, diffuse;
+      varying vec3 lightDir, eyeDir;
+      varying vec2 uv;
+      void main () {
+        float d = length(lightDir);
+        vec3 L = normalize(lightDir);
+        vec3 E = normalize(eyeDir);
+        vec3 N = normalize(2.0 * texture2D(normals, uv).rgb - 1.0);
+        N = vec3(-N.x, N.yz);
+        vec3 D = texture2D(diffuse, uv).rgb;
+        vec3 kD = D * (0.01 +
+          max(0.0, dot(L, N) * (0.6 + 0.8 / d) ));
+        vec3 S = texture2D(specular, uv).rgb;
+        vec3 kS = 2.0 * pow(max(0.0, dot(normalize(N + L), -E)), 10.0) * S;
+        gl_FragColor = vec4(kD + kS, 1);
+      }`,
+
+      vert: `
+      precision mediump float;
+      attribute vec2 position;
+      uniform vec2 lightPosition;
+      varying vec3 lightDir, eyeDir;
+      varying vec2 uv;
+      void main () {
+        vec2 P = 1.0 - 2.0 * position;
+        uv = vec2(position.x, 1.0 - position.y);
+        eyeDir = -vec3(P, 1);
+        lightDir = vec3(lightPosition - P, 1);
+        gl_Position = vec4(P, 0, 1);
+      }`,
+
+      attributes: {
+        position: [
+          -2, 0,
+          0, -2,
+          2, 2
+        ]
+      },
+
+      uniforms: {
+        specular: specular,
+        normals: normals,
+        diffuse: diffuse,
+        lightPosition: ({tick}) => {
+          var t = 0.025 * tick
+          return [2.0 * Math.cos(t), 2.0 * Math.sin(t)]
+        }
+      },
+
+      count: 3
+    })
+
+    regl.frame(() => {
+      draw()
+    })
+  }
+})

--- a/example/typescript/dependencies.d.ts
+++ b/example/typescript/dependencies.d.ts
@@ -1,0 +1,6 @@
+declare module 'angle-normals';
+declare module 'bunny';
+declare module 'gl-mat4';
+declare module 'mouse-change';
+declare module 'parse-dds';
+declare module 'resl';

--- a/example/typescript/dependencies.d.ts
+++ b/example/typescript/dependencies.d.ts
@@ -1,6 +1,11 @@
 declare module 'angle-normals';
+declare module 'baboon-image';
 declare module 'bunny';
 declare module 'gl-mat4';
+declare module 'gl-mat4/lookAt';
+declare module 'gl-mat4/perspective';
+declare module 'hsv2rgb';
 declare module 'mouse-change';
 declare module 'parse-dds';
 declare module 'resl';
+declare module 'vectorize-text';

--- a/example/typescript/dynamic.ts
+++ b/example/typescript/dynamic.ts
@@ -1,0 +1,73 @@
+/*
+  tags: basic
+
+  <p> This example shows how to pass props to draw commands </p>
+*/
+
+import REGL = require('../../regl')
+const regl = REGL()
+
+interface Uniforms {
+  angle: number;
+  color: REGL.Vec4;
+}
+
+interface Attributes {
+  position: number[];
+}
+
+interface Props {
+  color: REGL.Vec4;
+}
+
+const draw = regl<Uniforms, Attributes, Props>({
+  frag: `
+    precision mediump float;
+    uniform vec4 color;
+    void main() {
+      gl_FragColor = color;
+    }`,
+
+  vert: `
+    precision mediump float;
+    attribute vec2 position;
+    uniform float angle;
+    void main() {
+      gl_Position = vec4(
+        cos(angle) * position.x + sin(angle) * position.y,
+        -sin(angle) * position.x + cos(angle) * position.y, 0, 1);
+    }`,
+
+  attributes: {
+    position: [
+      -1, 0,
+      0, -1,
+      1, 1]
+  },
+
+  uniforms: {
+    color: regl.prop<Props, 'color'>('color'),
+    angle: ({tick}) => 0.01 * tick
+  },
+
+  depth: {
+    enable: false
+  },
+
+  count: 3
+})
+
+regl.frame(({tick}) => {
+  regl.clear({
+    color: [0, 0, 0, 1]
+  })
+
+  draw({
+    color: [
+      Math.sin(0.02 * (0.001 * tick)),
+      Math.cos(0.02 * (0.02 * tick)),
+      Math.sin(0.02 * (0.3 * tick)),
+      1
+    ]
+  })
+})

--- a/example/typescript/elements.ts
+++ b/example/typescript/elements.ts
@@ -1,0 +1,67 @@
+/*
+  tags: basic, lines
+<p> This example demonstrates how you can use `elements` to draw lines. </p>
+ */
+
+import REGL = require('../../regl')
+const regl = REGL()
+
+regl.clear({
+  color: [0, 0, 0, 1],
+  depth: 1
+})
+
+var lineWidth = 3
+if (lineWidth > regl.limits.lineWidthDims[1]) {
+  lineWidth = regl.limits.lineWidthDims[1]
+}
+
+interface Uniforms {
+  color: REGL.Vec4;
+}
+
+interface Attributes {
+  position: REGL.Vec2[];
+}
+
+regl<Uniforms, Attributes>({
+  frag: `
+    precision mediump float;
+    uniform vec4 color;
+    void main() {
+      gl_FragColor = color;
+    }`,
+
+  vert: `
+    precision mediump float;
+    attribute vec2 position;
+    void main() {
+      gl_Position = vec4(position, 0, 1);
+    }`,
+
+  attributes: {
+    position: (new Array(5)).fill(undefined).map((x, i): [number, number] => {
+      var theta = 2.0 * Math.PI * i / 5
+      return [ Math.sin(theta), Math.cos(theta) ]
+    })
+  },
+
+  uniforms: {
+    color: [1, 0, 0, 1]
+  },
+
+  elements: [
+    [0, 1],
+    [0, 2],
+    [0, 3],
+    [0, 4],
+    [1, 2],
+    [1, 3],
+    [1, 4],
+    [2, 3],
+    [2, 4],
+    [3, 4]
+  ],
+
+  lineWidth: lineWidth
+})()

--- a/example/typescript/envmap.ts
+++ b/example/typescript/envmap.ts
@@ -1,0 +1,182 @@
+/*
+  tags: advanced
+
+  <p>This example shows how you can render reflections with an environment map.</p>
+
+ */
+
+import REGL = require('../../regl')
+import mat4 = require('gl-mat4')
+import bunny = require('bunny')
+import normals = require('angle-normals')
+import resl = require('resl')
+
+const regl = REGL()
+
+namespace EnvMap {
+  export interface Uniforms {
+    envmap: REGL.TextureCube;
+  }
+  export interface Context {
+    view: REGL.Mat4;
+  }
+  export interface Props {
+    cube: REGL.TextureCube;
+  }
+}
+
+namespace Background {
+  export interface Uniforms {
+    view: REGL.Mat4;
+  }
+  export interface Attributes {
+    position: number[];
+  }
+}
+
+namespace Bunny {
+  export interface Uniforms extends Background.Uniforms {
+    projection: REGL.Mat4;
+    invView: REGL.Mat4;
+  }
+  export interface Attributes {
+    position: REGL.Vec3[];
+    normal: REGL.Vec3[];
+  }
+}
+
+const setupEnvMap = regl<
+  EnvMap.Uniforms & Background.Uniforms & Bunny.Uniforms,
+  {},
+  EnvMap.Props,
+  EnvMap.Context
+>({
+  context: {
+    view: ({tick}) => {
+      const t = 0.01 * tick
+      return mat4.lookAt([],
+        [30 * Math.cos(t), 2.5, 30 * Math.sin(t)],
+        [0, 2.5, 0],
+        [0, 1, 0])
+    }
+  },
+  frag: `
+  precision mediump float;
+  uniform samplerCube envmap;
+  varying vec3 reflectDir;
+  void main () {
+    gl_FragColor = textureCube(envmap, reflectDir);
+  }`,
+  uniforms: {
+    envmap: regl.prop<EnvMap.Props, 'cube'>('cube'),
+    view: regl.context<EnvMap.Context & REGL.DefaultContext, 'view'>('view'),
+    projection: ({viewportWidth, viewportHeight}) =>
+      mat4.perspective([],
+        Math.PI / 4,
+        viewportWidth / viewportHeight,
+        0.01,
+        1000),
+    invView: ({view}) => mat4.invert([], view)
+  }
+})
+
+const drawBackground = regl<{}, Background.Attributes>({
+  vert: `
+  precision mediump float;
+  attribute vec2 position;
+  uniform mat4 view;
+  varying vec3 reflectDir;
+  void main() {
+    reflectDir = (view * vec4(position, 1, 0)).xyz;
+    gl_Position = vec4(position, 0, 1);
+  }`,
+  attributes: {
+    position: [
+      -4, -4,
+      -4, 4,
+      8, 0]
+  },
+  depth: {
+    mask: false,
+    enable: false
+  },
+  count: 3
+})
+
+const drawBunny = regl<{}, Bunny.Attributes>({
+  vert: `
+  precision mediump float;
+  attribute vec3 position, normal;
+  uniform mat4 projection, view, invView;
+  varying vec3 reflectDir;
+  void main() {
+    vec4 eye = invView * vec4(0, 0, 0, 1);
+    reflectDir = reflect(
+      normalize(position.xyz - eye.xyz / eye.w),
+      normal);
+    gl_Position = projection * view * vec4(position, 1);
+  }`,
+  attributes: {
+    position: bunny.positions,
+    normal: normals(bunny.cells, bunny.positions)
+  },
+  elements: bunny.cells
+})
+
+interface Assets {
+  posx: HTMLImageElement;
+  negx: HTMLImageElement;
+  posy: HTMLImageElement;
+  negy: HTMLImageElement;
+  posz: HTMLImageElement;
+  negz: HTMLImageElement;
+}
+
+resl({
+  manifest: {
+    posx: {
+      type: 'image',
+      src: '../assets/posx.jpg'
+    },
+    negx: {
+      type: 'image',
+      src: '../assets/negx.jpg'
+    },
+    posy: {
+      type: 'image',
+      src: '../assets/posy.jpg'
+    },
+    negy: {
+      type: 'image',
+      src: '../assets/negy.jpg'
+    },
+    posz: {
+      type: 'image',
+      src: '../assets/posz.jpg'
+    },
+    negz: {
+      type: 'image',
+      src: '../assets/negz.jpg'
+    }
+  },
+
+  onDone: ({ posx, negx, posy, negy, posz, negz }: Assets) => {
+    const cube = regl.cube(
+      posx, negx,
+      posy, negy,
+      posz, negz)
+    regl.frame(() => {
+      setupEnvMap({ cube }, () => {
+        drawBackground()
+        drawBunny()
+      })
+    })
+  },
+
+  onProgress: (fraction: number) => {
+    const intensity = 1.0 - fraction
+    regl.clear({
+      color: [intensity, intensity, intensity, 1]
+    })
+  }
+})

--- a/example/typescript/feedback.ts
+++ b/example/typescript/feedback.ts
@@ -1,0 +1,81 @@
+/*
+  tags: basic
+
+ <p> This example shows how to use copyTexImage2D to implement feedback effects </p>
+ */
+
+import REGL = require('../../regl')
+import MouseChange = require('mouse-change')
+
+const regl = REGL()
+const mouse = MouseChange()
+
+interface Uniforms {
+  texture: REGL.Texture2D;
+  mouse: REGL.Vec2;
+  t: number;
+}
+
+interface Attributes {
+  position: number[];
+}
+
+const pixels = regl.texture()
+
+const drawFeedback = regl<Uniforms, Attributes>({
+  frag: `
+  precision mediump float;
+  uniform sampler2D texture;
+  uniform vec2 mouse;
+  uniform float t;
+  varying vec2 uv;
+  void main () {
+    float dist = length(gl_FragCoord.xy - mouse);
+    gl_FragColor = vec4(0.98 * texture2D(texture,
+      uv + cos(t) * vec2(0.5 - uv.y, uv.x - 0.5) - sin(2.0 * t) * (uv - 0.5)).rgb, 1) +
+      exp(-0.01 * dist) * vec4(
+        1.0 + cos(2.0 * t),
+        1.0 + cos(2.0 * t + 1.5),
+        1.0 + cos(2.0 * t + 3.0),
+        0.0);
+  }`,
+
+  vert: `
+  precision mediump float;
+  attribute vec2 position;
+  varying vec2 uv;
+  void main () {
+    uv = position;
+    gl_Position = vec4(2.0 * position - 1.0, 0, 1);
+  }`,
+
+  attributes: {
+    position: [
+      -2, 0,
+      0, -2,
+      2, 2]
+  },
+
+  uniforms: {
+    texture: pixels,
+    mouse: ({pixelRatio, viewportHeight}) => [
+      mouse.x * pixelRatio,
+      viewportHeight - mouse.y * pixelRatio
+    ],
+    t: ({tick}) => 0.01 * tick
+  },
+
+  count: 3
+})
+
+regl.frame(function () {
+  regl.clear({
+    color: [0, 0, 0, 1]
+  })
+
+  drawFeedback()
+
+  pixels({
+    copy: true
+  })
+})

--- a/example/typescript/geomorph.ts
+++ b/example/typescript/geomorph.ts
@@ -1,0 +1,174 @@
+/*
+  tags: advanced
+
+  <p>No description</p>
+ */
+import REGL = require('../../regl')
+import mat4 = require('gl-mat4')
+import bunny = require('bunny')
+
+const regl = REGL()
+
+// We'll generate 4 refined levels of detail for the bunny mesh
+const NUM_LODS = 4
+
+// First we extract the edges from the bunny mesh
+const lodCells: REGL.Vec2[] = bunny.cells.reduce((edges: REGL.Vec2[], cell: REGL.Vec3) => {
+  edges.push(
+    [cell[0], cell[1]],
+    [cell[1], cell[2]],
+    [cell[2], cell[0]])
+  return edges
+}, [])
+
+// We initialize the finest level of detail to be just the mesh
+const lodPositions: REGL.Vec3[][] = [bunny.positions]
+const lodOffsets: number[] = [lodCells.length]
+
+// For each level of detail, we cluster the vertices and then move all
+// of the non-degenerate cells to the front of the buffer
+for (let lod = 1; lod <= NUM_LODS; ++lod) {
+  const points: REGL.Vec3[] = lodPositions[lod - 1]
+
+  // Here we use an exponentially growing bin size, though you could really
+  // use whatever you like here as long as it is monotonically increasing
+  const binSize = 0.2 * Math.pow(2.2, lod)
+
+  // For the first phase of clustering, we map each vertex into a bin
+  const grid = {} as { [binId: string]: number[] }
+  points.forEach((p, i) => {
+    const binId = p.map((x) => Math.floor(x / binSize)).join()
+    if (binId in grid) {
+      grid[binId].push(i)
+    } else {
+      grid[binId] = [i]
+    }
+  })
+
+  // Next we iterate over the bins and snap each vertex to the centroid of
+  // all vertices in its bin
+  const snapped = Array(points.length)
+  Object.keys(grid).forEach((binId) => {
+    const bin = grid[binId]
+    const centroid = [0, 0, 0]
+    bin.forEach(function (idx) {
+      const p = points[idx]
+      for (let i = 0; i < 3; ++i) {
+        centroid[i] += p[i] / bin.length
+      }
+    })
+    bin.forEach(function (idx) {
+      snapped[idx] = centroid
+    })
+  })
+  lodPositions.push(snapped)
+
+  // Finally we partition the cell array in place so that all non-degenerate
+  // cells are moved to the front of the array
+  const cellCount = lodOffsets[lod - 1]
+  let ptr = 0
+  for (let idx = 0; idx < cellCount; ++idx) {
+    const cell = lodCells[idx]
+    if (snapped[cell[0]] !== snapped[cell[1]]) {
+      lodCells[idx] = lodCells[ptr]
+      lodCells[ptr++] = cell
+    }
+  }
+
+  // And we save this offset of the last non degenerate cell so that when we
+  // draw at this level of detail we don't waste time drawing degenerate cells
+  lodOffsets.push(ptr)
+}
+
+// Now that the LODs are computed we upload them to the GPU
+const lodBuffers: REGL.Buffer[] = lodPositions.map(regl.buffer)
+
+interface Uniforms {
+  lod: number;
+  view: REGL.Mat4;
+  projection: REGL.Mat4;
+}
+
+interface Attributes {
+  p0: REGL.Buffer;
+  p1: REGL.Buffer;
+}
+
+interface Props {
+  lod: number;
+}
+
+// Ok!  It's time to define our command:
+const drawBunnyWithLOD = regl<Uniforms, Attributes, Props>({
+  vert: `
+  precision mediump float;
+
+  // p0 and p1 are the two LOD arrays for this command
+  attribute vec3 p0, p1;
+  uniform float lod;
+
+  uniform mat4 view, projection;
+
+  varying vec3 fragColor;
+  void main () {
+    vec3 position = mix(p0, p1, lod);
+    fragColor = 0.5 + (0.2 * position);
+    gl_Position = projection * view * vec4(position, 1);
+  }`,
+
+  frag: `
+  precision mediump float;
+  varying vec3 fragColor;
+  void main() {
+    gl_FragColor = vec4(fragColor, 1);
+  }`,
+
+  // We take the two LOD attributes directly above and below the current
+  // fractional LOD
+  attributes: {
+    p0: (_, {lod}) => lodBuffers[Math.floor(lod)],
+    p1: (_, {lod}) => lodBuffers[Math.ceil(lod)]
+  },
+
+  // For the elements we use the LOD-orderd array of edges that we computed
+  // earlier.  regl automatically infers the primitive type from this data.
+  elements: lodCells,
+
+  uniforms: {
+    // This is a standard perspective camera
+    projection: ({viewportWidth, viewportHeight}) => mat4.perspective([],
+      Math.PI / 4,
+      viewportWidth / viewportHeight,
+      0.01,
+      1000),
+
+    // We slowly rotate the camera around the center of the bunny
+    view: ({tick}) => {
+      const t = 0.004 * tick
+      return mat4.lookAt([],
+        [20 * Math.cos(t), 10, 20 * Math.sin(t)],
+        [0, 2.5, 0],
+        [0, 1, 0])
+    },
+
+    // We set the lod uniform to be the fractional LOD
+    lod: (_, {lod}) => lod - Math.floor(lod)
+  },
+
+  // Finally we only draw as many primitives as are present in the finest LOD
+  count: (_, {lod}) => 2 * lodOffsets[Math.floor(lod)]
+})
+
+regl.frame(({tick}) => {
+  regl.clear({
+    depth: 1,
+    color: [0, 0, 0, 1]
+  })
+
+  // To use the LOD draw command, we just pass it an object with the LOD as
+  // a single property:
+  drawBunnyWithLOD({
+    lod: Math.min(NUM_LODS, Math.max(0,
+      0.5 * NUM_LODS * (1 + Math.cos(0.003 * tick))))
+  })
+})

--- a/example/typescript/life.ts
+++ b/example/typescript/life.ts
@@ -1,0 +1,92 @@
+/*
+  tags: fbo, basic
+
+  <p>This example implements the game of life in regl.</p>
+
+ */
+
+import REGL = require('../../regl')
+const regl = REGL()
+
+const RADIUS = 512
+const INITIAL_CONDITIONS = (Array(RADIUS * RADIUS * 4)).fill(0).map(
+  () => Math.random() > 0.9 ? 255 : 0)
+
+const state: REGL.Framebuffer2D[] = (Array(2)).fill(undefined).map(() =>
+  regl.framebuffer({
+    color: regl.texture({
+      radius: RADIUS,
+      data: INITIAL_CONDITIONS,
+      wrap: 'repeat'
+    }),
+    depthStencil: false
+  }))
+
+interface Uniforms {
+  prevState: REGL.Framebuffer2D;
+}
+
+interface Attributes {
+  position: number[];
+}
+
+const updateLife = regl<Uniforms, Attributes>({
+  frag: `
+  precision mediump float;
+  uniform sampler2D prevState;
+  varying vec2 uv;
+  void main() {
+    float n = 0.0;
+    for(int dx=-1; dx<=1; ++dx)
+    for(int dy=-1; dy<=1; ++dy) {
+      n += texture2D(prevState, uv+vec2(dx,dy)/float(${RADIUS})).r;
+    }
+    float s = texture2D(prevState, uv).r;
+    if(n > 3.0+s || n < 3.0) {
+      gl_FragColor = vec4(0,0,0,1);
+    } else {
+      gl_FragColor = vec4(1,1,1,1);
+    }
+  }`,
+
+  framebuffer: ({tick}) => state[(tick + 1) % 2]
+})
+
+const setupQuad = regl<Uniforms, Attributes>({
+  frag: `
+  precision mediump float;
+  uniform sampler2D prevState;
+  varying vec2 uv;
+  void main() {
+    float state = texture2D(prevState, uv).r;
+    gl_FragColor = vec4(vec3(state), 1);
+  }`,
+
+  vert: `
+  precision mediump float;
+  attribute vec2 position;
+  varying vec2 uv;
+  void main() {
+    uv = 0.5 * (position + 1.0);
+    gl_Position = vec4(position, 0, 1);
+  }`,
+
+  attributes: {
+    position: [ -4, -4, 4, -4, 0, 4 ]
+  },
+
+  uniforms: {
+    prevState: ({tick}) => state[tick % 2]
+  },
+
+  depth: { enable: false },
+
+  count: 3
+})
+
+regl.frame(() => {
+  setupQuad(() => {
+    regl.draw()
+    updateLife()
+  })
+})

--- a/example/typescript/lighting.ts
+++ b/example/typescript/lighting.ts
@@ -1,0 +1,130 @@
+/*
+  tags: basic, lighting
+
+  <p>This example shows how you can apply multiple light sources to a model</p>
+
+ */
+import REGL = require('../../regl')
+import normals = require('angle-normals')
+import mat4 = require('gl-mat4')
+import bunny = require('bunny')
+
+const regl = REGL()
+
+interface Uniforms {
+  view: REGL.Mat4;
+  projection: REGL.Mat4;
+  'lights[0].color': REGL.Vec3;
+  'lights[1].color': REGL.Vec3;
+  'lights[2].color': REGL.Vec3;
+  'lights[3].color': REGL.Vec3;
+  'lights[0].position': REGL.Vec3;
+  'lights[1].position': REGL.Vec3;
+  'lights[2].position': REGL.Vec3;
+  'lights[3].position': REGL.Vec3;
+}
+
+interface Attributes {
+  position: REGL.Vec3[];
+  normal: REGL.Vec3[];
+}
+
+const drawBunny = regl<Uniforms, Attributes>({
+  vert: `
+  precision mediump float;
+  attribute vec3 position, normal;
+  uniform mat4 view, projection;
+  varying vec3 fragNormal, fragPosition;
+  void main() {
+    fragNormal = normal;
+    fragPosition = position;
+    gl_Position = projection * view * vec4(position, 1);
+  }`,
+
+  frag: `
+  precision mediump float;
+  struct Light {
+    vec3 color;
+    vec3 position;
+  };
+  uniform Light lights[4];
+  varying vec3 fragNormal, fragPosition;
+  void main() {
+    vec3 normal = normalize(fragNormal);
+    vec3 light = vec3(0, 0, 0);
+    for (int i = 0; i < 4; ++i) {
+      vec3 lightDir = normalize(lights[i].position - fragPosition);
+      float diffuse = max(0.0, dot(lightDir, normal));
+      light += diffuse * lights[i].color;
+    }
+    gl_FragColor = vec4(light, 1);
+  }`,
+
+  attributes: {
+    position: bunny.positions,
+    normal: normals(bunny.cells, bunny.positions)
+  },
+
+  elements: bunny.cells,
+
+  uniforms: {
+    view: ({tick}) => {
+      const t = 0.01 * tick
+      return mat4.lookAt([],
+        [30 * Math.cos(t), 2.5, 30 * Math.sin(t)],
+        [0, 2.5, 0],
+        [0, 1, 0])
+    },
+    projection: ({viewportWidth, viewportHeight}) =>
+      mat4.perspective([],
+        Math.PI / 4,
+        viewportWidth / viewportHeight,
+        0.01,
+        1000),
+    'lights[0].color': [1, 0, 0],
+    'lights[1].color': [0, 1, 0],
+    'lights[2].color': [0, 0, 1],
+    'lights[3].color': [1, 1, 0],
+    'lights[0].position': ({tick}) => {
+      const t = 0.1 * tick
+      return [
+        10 * Math.cos(0.09 * (t)),
+        10 * Math.sin(0.09 * (2 * t)),
+        10 * Math.cos(0.09 * (3 * t))
+      ]
+    },
+    'lights[1].position': ({tick}) => {
+      const t = 0.1 * tick
+      return [
+        10 * Math.cos(0.05 * (5 * t + 1)),
+        10 * Math.sin(0.05 * (4 * t)),
+        10 * Math.cos(0.05 * (0.1 * t))
+      ]
+    },
+    'lights[2].position': ({tick}) => {
+      const t = 0.1 * tick
+      return [
+        10 * Math.cos(0.05 * (9 * t)),
+        10 * Math.sin(0.05 * (0.25 * t)),
+        10 * Math.cos(0.05 * (4 * t))
+      ]
+    },
+    'lights[3].position': ({tick}) => {
+      const t = 0.1 * tick
+      return [
+        10 * Math.cos(0.1 * (0.3 * t)),
+        10 * Math.sin(0.1 * (2.1 * t)),
+        10 * Math.cos(0.1 * (1.3 * t))
+      ]
+    }
+  }
+})
+
+regl.frame(() => {
+  regl.clear({
+    depth: 1,
+    color: [0, 0, 0, 1]
+  })
+
+  drawBunny()
+})

--- a/example/typescript/mipmap.ts
+++ b/example/typescript/mipmap.ts
@@ -1,0 +1,76 @@
+/*
+  tags: basic
+
+  <p>This example shows how you can use mipmaps in regl.</p>
+
+ */
+
+import REGL = require('../../regl')
+const regl = REGL()
+
+interface Uniforms {
+  texture: REGL.Texture2D;
+  tick: number;
+}
+
+interface Attributes {
+  position: number[];
+}
+
+const drawCheckerboard = regl<Uniforms, Attributes>({
+  frag: `
+  precision mediump float;
+  uniform sampler2D texture;
+  uniform float tick;
+  varying vec2 uv;
+  void main () {
+    mat3 m = mat3(
+      cos(tick), sin(tick), -1.1 + cos(tick),
+      -sin(tick), cos(tick), 0,
+      0, 0, 1);
+    vec3 p = m * vec3(uv, 1);
+    gl_FragColor = texture2D(texture, p.xy / p.z);
+  }`,
+
+  vert: `
+  precision mediump float;
+  attribute vec2 position;
+  varying vec2 uv;
+  void main () {
+    uv = position;
+    gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
+  }`,
+
+  attributes: {
+    position: [
+      -2, 0,
+      0, -2,
+      2, 2]
+  },
+
+  uniforms: {
+    tick: ({tick}) => 0.005 * tick,
+
+    texture: regl.texture({
+      min: 'linear mipmap linear',
+      mag: 'nearest',
+      wrap: 'repeat',
+      data: [
+        [255, 255, 255, 255, 0, 0, 0, 0],
+        [255, 255, 255, 255, 0, 0, 0, 0],
+        [255, 255, 255, 255, 0, 0, 0, 0],
+        [255, 255, 255, 255, 0, 0, 0, 0],
+        [0, 0, 0, 0, 255, 255, 255, 255],
+        [0, 0, 0, 0, 255, 255, 255, 255],
+        [0, 0, 0, 0, 255, 255, 255, 255],
+        [0, 0, 0, 0, 255, 255, 255, 255]
+      ]
+    })
+  },
+
+  count: 3
+})
+
+regl.frame(() => {
+  drawCheckerboard()
+})

--- a/example/typescript/particles.ts
+++ b/example/typescript/particles.ts
@@ -1,0 +1,118 @@
+/*
+  tags: basic
+
+  <p>This example show how you can render point particles in regl</p>
+ */
+
+import REGL = require('../../regl')
+import mat4 = require('gl-mat4')
+import hsv2rgb = require('hsv2rgb')
+
+const regl = REGL()
+
+const NUM_POINTS = 1e4
+const VERT_SIZE = 4 * (4 + 4 + 3)
+
+const pointBuffer = regl.buffer(Array(NUM_POINTS).fill(undefined).map(function () {
+  const color = hsv2rgb(Math.random() * 360, 0.6, 1)
+  return [
+    // freq
+    Math.random() * 10,
+    Math.random() * 10,
+    Math.random() * 10,
+    Math.random() * 10,
+    // phase
+    2.0 * Math.PI * Math.random(),
+    2.0 * Math.PI * Math.random(),
+    2.0 * Math.PI * Math.random(),
+    2.0 * Math.PI * Math.random(),
+    // color
+    color[0] / 255, color[1] / 255, color[2] / 255
+  ]
+}))
+
+interface Uniforms {
+  time: number;
+  view: REGL.Mat4;
+  projection: REGL.Mat4;
+}
+
+interface Attributes {
+  freq: REGL.AttributeConfig;
+  phase: REGL.AttributeConfig;
+  color: REGL.AttributeConfig;
+}
+
+const drawParticles = regl<Uniforms, Attributes>({
+  vert: `
+  precision mediump float;
+  attribute vec4 freq, phase;
+  attribute vec3 color;
+  uniform float time;
+  uniform mat4 view, projection;
+  varying vec3 fragColor;
+  void main() {
+    vec3 position = 8.0 * cos(freq.xyz * time + phase.xyz);
+    gl_PointSize = 5.0 * (1.0 + cos(freq.w * time + phase.w));
+    gl_Position = projection * view * vec4(position, 1);
+    fragColor = color;
+  }`,
+
+  frag: `
+  precision lowp float;
+  varying vec3 fragColor;
+  void main() {
+    if (length(gl_PointCoord.xy - 0.5) > 0.5) {
+      discard;
+    }
+    gl_FragColor = vec4(fragColor, 1);
+  }`,
+
+  attributes: {
+    freq: {
+      buffer: pointBuffer,
+      stride: VERT_SIZE,
+      offset: 0
+    },
+    phase: {
+      buffer: pointBuffer,
+      stride: VERT_SIZE,
+      offset: 16
+    },
+    color: {
+      buffer: pointBuffer,
+      stride: VERT_SIZE,
+      offset: 32
+    }
+  },
+
+  uniforms: {
+    view: ({tick}) => {
+      const t = 0.01 * tick
+      return mat4.lookAt([],
+        [30 * Math.cos(t), 2.5, 30 * Math.sin(t)],
+        [0, 0, 0],
+        [0, 1, 0])
+    },
+    projection: ({viewportWidth, viewportHeight}) =>
+      mat4.perspective([],
+        Math.PI / 4,
+        viewportWidth / viewportHeight,
+        0.01,
+        1000),
+    time: ({tick}) => tick * 0.001
+  },
+
+  count: NUM_POINTS,
+
+  primitive: 'points'
+})
+
+regl.frame(() => {
+  regl.clear({
+    depth: 1,
+    color: [0, 0, 0, 1]
+  })
+
+  drawParticles()
+})

--- a/example/typescript/scope.ts
+++ b/example/typescript/scope.ts
@@ -1,0 +1,77 @@
+/*
+  tags: basic
+
+  <p>This examples demonstrates scopes</p>
+
+ */
+
+import REGL = require('../../regl')
+const regl = REGL()
+
+regl.clear({
+  color: [0, 0, 0, 1],
+  depth: 1
+})
+
+interface Uniforms {
+  color: REGL.Vec4;
+  offset: REGL.Vec2;
+}
+
+interface Attributes {
+  position: number[]
+}
+
+regl<Uniforms, Attributes>({
+  frag: `
+    precision mediump float;
+    uniform vec4 color;
+    void main() {
+      gl_FragColor = color;
+    }`,
+
+  vert: `
+    precision mediump float;
+    attribute vec2 position;
+    uniform vec2 offset;
+    void main() {
+      gl_Position = vec4(position + offset, 0, 1);
+    }`,
+
+  attributes: {
+    position: [
+      0.5, 0,
+      0, 0.5,
+      1, 1]
+  },
+
+  count: 3
+})(() => {
+  regl<Uniforms, Attributes>({
+    uniforms: {
+      color: [1, 0, 0, 1],
+      offset: [0, 0]
+    }
+  })()
+
+  regl<Uniforms, Attributes>({
+    uniforms: {
+      color: [0, 0, 1, 1],
+      offset: [-1, 0]
+    }
+  })()
+
+  regl<Uniforms, Attributes>({
+    uniforms: {
+      color: [0, 1, 0, 1],
+      offset: [0, -1]
+    }
+  })()
+
+  regl<Uniforms, Attributes>({
+    uniforms: {
+      color: [1, 1, 1, 1],
+      offset: [-1, -1]
+    }
+  })()
+})

--- a/example/typescript/text.ts
+++ b/example/typescript/text.ts
@@ -1,0 +1,136 @@
+/*
+  tags: basic
+
+  <p>This example shows how you can draw vectorized text in regl.</p>
+
+ */
+
+import REGL = require('../../regl')
+import vectorizeText = require('vectorize-text')
+import perspective = require('gl-mat4/perspective')
+import lookAt = require('gl-mat4/lookAt')
+
+const regl = REGL()
+
+interface TextMesh {
+  edges: REGL.Vec2;
+  positions: REGL.Vec2;
+}
+
+const textMesh: TextMesh = vectorizeText('hello regl!', {
+  textAlign: 'center',
+  textBaseline: 'middle'
+})
+
+const feedBackTexture = regl.texture({
+  copy: true,
+  min: 'linear',
+  mag: 'linear'
+})
+
+interface UniformsFeedback {
+  t: number;
+  texture: REGL.Texture2D;
+}
+
+interface UniformsText {
+  t: number;
+  projection: REGL.Mat4;
+  view: REGL.Mat4;
+}
+
+interface Attributes {
+  position: number[];
+}
+
+const drawFeedback = regl<UniformsFeedback, Attributes>({
+  frag: `
+  precision mediump float;
+  uniform sampler2D texture;
+  uniform float t;
+  varying vec2 uv;
+  void main () {
+    vec2 warp = uv + 0.01 * sin(t) * vec2(0.5 - uv.y, uv.x - 0.5)
+      - 0.01 * (uv - 0.5);
+    gl_FragColor = vec4(0.98 * texture2D(texture, warp).rgb, 1);
+  }`,
+
+  vert: `
+  precision mediump float;
+  attribute vec2 position;
+  varying vec2 uv;
+  void main () {
+    uv = position;
+    gl_Position = vec4(2.0 * position - 1.0, 0, 1);
+  }`,
+
+  attributes: {
+    position: [-2, 0, 0, -2, 2, 2]
+  },
+
+  uniforms: {
+    texture: feedBackTexture,
+    t: ({tick}) => 0.001 * tick
+  },
+
+  depth: {enable: false},
+
+  count: 3
+})
+
+const drawText = regl<UniformsText, Attributes>({
+  frag: `
+  precision mediump float;
+  uniform float t;
+  void main () {
+    gl_FragColor = vec4(
+      1.0 + cos(2.0 * t),
+      1.0 + cos(2.1 * t + 1.0),
+      1.0 + cos(2.2 * t + 2.0),
+      1);
+  }`,
+
+  vert: `
+  attribute vec2 position;
+  uniform mat4 projection, view;
+  void main () {
+    gl_Position = projection * view * vec4(position, 0, 1);
+  }`,
+
+  attributes: {
+    position: textMesh.positions
+  },
+
+  elements: textMesh.edges,
+
+  uniforms: {
+    t: ({tick}) => 0.01 * tick,
+
+    view: ({tick}) => {
+      const t = 0.01 * tick
+      return lookAt([],
+        [5 * Math.sin(t), 0, -5 * Math.cos(t)],
+        [0, 0, 0],
+        [0, -1, 0])
+    },
+
+    projection: ({viewportWidth, viewportHeight}) =>
+      perspective([],
+        Math.PI / 4,
+        viewportWidth / viewportHeight,
+        0.01,
+        1000)
+  },
+
+  depth: {enable: false}
+})
+
+regl.frame(() => {
+  drawFeedback()
+  drawText()
+  feedBackTexture({
+    copy: true,
+    min: 'linear',
+    mag: 'linear'
+  })
+})

--- a/example/typescript/texture.ts
+++ b/example/typescript/texture.ts
@@ -1,0 +1,51 @@
+/*
+  tags: basic
+
+  <p>This example shows how you can load and draw a texture in regl</p>
+
+ */
+
+import REGL = require('../../regl')
+import baboon = require('baboon-image')
+
+const regl = REGL()
+
+interface Uniforms {
+  texture: REGL.Texture2D;
+}
+
+interface Attributes {
+  position: number[];
+}
+
+regl<Uniforms, Attributes>({
+  frag: `
+  precision mediump float;
+  uniform sampler2D texture;
+  varying vec2 uv;
+  void main () {
+    gl_FragColor = texture2D(texture, uv);
+  }`,
+
+  vert: `
+  precision mediump float;
+  attribute vec2 position;
+  varying vec2 uv;
+  void main () {
+    uv = position;
+    gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
+  }`,
+
+  attributes: {
+    position: [
+      -2, 0,
+      0, -2,
+      2, 2]
+  },
+
+  uniforms: {
+    texture: regl.texture(baboon)
+  },
+
+  count: 3
+})()

--- a/example/typescript/theta360.ts
+++ b/example/typescript/theta360.ts
@@ -1,0 +1,149 @@
+/*
+  tags: basic
+
+  <p>This example shows how to render a 360 panoramic environment map.</p>
+
+ */
+
+import REGL = require('../../regl')
+import mat4 = require('gl-mat4')
+import bunny = require('bunny')
+import normals = require('angle-normals')
+import resl = require('resl')
+
+const regl = REGL()
+
+const envmap = regl.texture()
+
+interface SetupProps {
+  view: REGL.Mat4;
+}
+
+interface Uniforms extends SetupProps {
+  envmap: REGL.Texture2D;
+  projection: REGL.Mat4;
+  invView: REGL.Mat4;
+}
+
+interface AttributesBackground {
+  position: number[]
+}
+
+interface AttributesBunny {
+  position: REGL.Vec3[];
+  normal: REGL.Vec3[];
+}
+
+const setupEnvMap = regl<Uniforms, {}, SetupProps>({
+  frag: `
+  precision mediump float;
+  uniform sampler2D envmap;
+  varying vec3 reflectDir;
+
+  #define PI ${Math.PI}
+
+  vec4 lookupEnv (vec3 dir) {
+    float lat = atan(dir.z, dir.x);
+    float lon = acos(dir.y / length(dir));
+    return texture2D(envmap, vec2(
+      0.5 + lat / (2.0 * PI),
+      lon / PI));
+  }
+
+  void main () {
+    gl_FragColor = lookupEnv(reflectDir);
+  }`,
+
+  uniforms: {
+    envmap: envmap,
+
+    view: regl.prop<SetupProps, 'view'>('view'),
+
+    projection: ({viewportWidth, viewportHeight}) =>
+      mat4.perspective([],
+        Math.PI / 4,
+        viewportWidth / viewportHeight,
+        0.01,
+        1000),
+
+    invView: (context, {view}) => mat4.invert([], view)
+  }
+})
+
+const drawBackground = regl<Uniforms, AttributesBackground>({
+  vert: `
+  precision mediump float;
+  attribute vec2 position;
+  uniform mat4 view;
+  varying vec3 reflectDir;
+  void main() {
+    reflectDir = (view * vec4(position, 1, 0)).xyz;
+    gl_Position = vec4(position, 0, 1);
+  }`,
+
+  attributes: {
+    position: [
+      -4, -4,
+      -4, 4,
+      8, 0]
+  },
+
+  depth: {
+    mask: false,
+    enable: false
+  },
+
+  count: 3
+})
+
+const drawBunny = regl<Uniforms, AttributesBunny>({
+  vert: `
+  precision mediump float;
+  attribute vec3 position, normal;
+  uniform mat4 projection, view, invView;
+  varying vec3 reflectDir;
+  void main() {
+    vec4 cameraPosition = view * vec4(position, 1);
+    vec3 eye = normalize(position - invView[3].xyz / invView[3].w);
+    reflectDir = reflect(eye, normal);
+    gl_Position = projection * cameraPosition;
+  }`,
+
+  attributes: {
+    position: bunny.positions,
+    normal: normals(bunny.cells, bunny.positions)
+  },
+
+  elements: bunny.cells
+})
+
+resl({
+  manifest: {
+    envmap: {
+      type: 'image',
+      stream: true,
+      src: '../assets/ogd-oregon-360.jpg',
+      parser: envmap
+    }
+  },
+  onDone: () => {
+    regl.frame(({tick}) => {
+      const t = 0.01 * tick
+      setupEnvMap({
+        view: mat4.lookAt([],
+          [30 * Math.cos(t), 2.5, 30 * Math.sin(t)],
+          [0, 2.5, 0],
+          [0, 1, 0])
+      }, () => {
+        drawBackground()
+        drawBunny()
+      })
+    })
+  },
+  onProgress: (fraction: number) => {
+    const intensity = 1.0 - fraction
+    regl.clear({
+      color: [intensity, intensity, intensity, 1]
+    })
+  }
+})

--- a/example/typescript/tile.ts
+++ b/example/typescript/tile.ts
@@ -1,0 +1,107 @@
+/*
+  tags: basic
+
+  <p>This example implements a simple 2D tiled sprite renderer.</p>
+
+ */
+
+import REGL = require('../../regl')
+import MouseChange = require('mouse-change')
+import resl = require('resl')
+
+const regl = REGL()
+const mouse = MouseChange()
+
+interface Props {
+  view: REGL.Vec4;
+}
+
+interface Assets {
+  map: REGL.Vec2[][];
+  tiles: REGL.Texture2D;
+}
+
+interface Uniforms extends Props {
+  map: REGL.Texture2D;
+  tiles: REGL.Texture2D;
+  mapSize: REGL.Vec2;
+  tileSize: REGL.Vec2;
+}
+
+interface Attributes {
+  position: number[];
+}
+
+resl({
+  manifest: {
+    map: {
+      type: 'text',
+      src: '../assets/map.json',
+      parser: JSON.parse
+    },
+
+    tiles: {
+      type: 'image',
+      src: '../assets/tiles.png',
+      parser: regl.texture
+    }
+  },
+
+  onDone: ({map, tiles}: Assets) => {
+    const drawBackground = regl<Uniforms, Attributes, Props>({
+      frag: `
+      precision mediump float;
+      uniform sampler2D map, tiles;
+      uniform vec2 mapSize, tileSize;
+      varying vec2 uv;
+      void main() {
+        vec2 tileCoord = floor(255.0 * texture2D(map, floor(uv) / mapSize).ra);
+        gl_FragColor = texture2D(tiles, (tileCoord + fract(uv)) / tileSize);
+      }`,
+
+      vert: `
+      precision mediump float;
+      attribute vec2 position;
+      uniform vec4 view;
+      varying vec2 uv;
+      void main() {
+        uv = mix(view.xw, view.zy, 0.5 * (1.0 + position));
+        gl_Position = vec4(position, 1, 1);
+      }`,
+
+      depth: { enable: false },
+
+      uniforms: {
+        tiles,
+        tileSize: [16.0, 16.0],
+        map: regl.texture(map),
+        mapSize: [map[0].length, map.length],
+        view: regl.prop<Props, 'view'>('view')
+      },
+
+      attributes: {
+        position: [ -1, -1, 1, -1, -1, 1, 1, 1, -1, 1, 1, -1 ]
+      },
+
+      count: 6
+    })
+
+    regl.frame(({viewportWidth, viewportHeight}) => {
+      const {x, y} = mouse
+
+      const boxX = map[0].length * x / viewportWidth
+      const boxY = map.length * y / viewportHeight
+      const boxH = 10
+      const boxW = viewportWidth / viewportHeight * boxH
+
+      drawBackground({
+        view: [
+          boxX - 0.5 * boxW,
+          boxY - 0.5 * boxH,
+          boxX + 0.5 * boxW,
+          boxY + 0.5 * boxH
+        ]
+      })
+    })
+  }
+})

--- a/example/typescript/video.ts
+++ b/example/typescript/video.ts
@@ -1,0 +1,104 @@
+/*
+  tags: basic, video
+
+  <p>This example shows how to overlay a chroma keyed video over a background rendered by regl. </p>
+
+ */
+
+import REGL = require('../../regl')
+import resl = require('resl')
+
+const regl = REGL()
+
+interface Props {
+  video: REGL.Texture2D;
+}
+
+interface Uniforms {
+  texture: REGL.Texture2D;
+  screenShape: REGL.Vec2;
+  time: number;
+}
+
+interface Attributes {
+  position: number[];
+}
+
+const drawDoggie = regl<Uniforms, Attributes, Props>({
+  frag: `
+  precision mediump float;
+  uniform sampler2D texture;
+  uniform vec2 screenShape;
+  uniform float time;
+
+  varying vec2 uv;
+
+  vec4 background () {
+    vec2 pos = 0.5 - gl_FragCoord.xy / screenShape;
+    float r = length(pos);
+    float theta = atan(pos.y, pos.x);
+    return vec4(
+      cos(pos.x * time) + sin(pos.y * pos.x * time),
+      cos(100.0 * r * cos(0.3 * time) + theta),
+      sin(time / r + pos.x * cos(10.0 * time + 3.0)),
+      1);
+  }
+
+  void main () {
+    vec4 color = texture2D(texture, uv);
+    float chromakey = step(0.15 + max(color.r, color.b), color.g);
+    gl_FragColor = mix(color, background(), chromakey);
+  }`,
+
+  vert: `
+  precision mediump float;
+  attribute vec2 position;
+  varying vec2 uv;
+  void main () {
+    uv = position;
+    gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
+  }`,
+
+  attributes: {
+    position: [
+      -2, 0,
+      0, -2,
+      2, 2]
+  },
+
+  uniforms: {
+    texture: regl.prop<Props, 'video'>('video'),
+
+    screenShape: ({viewportWidth, viewportHeight}) =>
+      [viewportWidth, viewportHeight],
+
+    time: regl.context('time')
+  },
+
+  count: 3
+})
+
+interface Assets {
+  video: HTMLVideoElement;
+}
+
+resl({
+  manifest: {
+    video: {
+      type: 'video',
+      src: '../assets/doggie-chromakey.ogv',
+      stream: true
+    }
+  },
+
+  onDone: ({video}: Assets) => {
+    video.autoplay = true
+    video.loop = true
+    video.play()
+
+    const texture = regl.texture(video)
+    regl.frame(() => {
+      drawDoggie({ video: texture.subimage(video) })
+    })
+  }
+})

--- a/example/util/camera.d.ts
+++ b/example/util/camera.d.ts
@@ -1,0 +1,25 @@
+import REGL = require('../../regl')
+export = createCamera
+
+interface Props {
+  center?: number[];
+  theta?: number;
+  phi?: number;
+  distance?: number;
+  up?: REGL.Vec3;
+  minDistance?: number;
+  maxDistance?: number;
+}
+
+interface Context extends REGL.DefaultContext {
+  view: REGL.Mat4;
+  projection: REGL.Mat4;
+  center: Float32Array;
+  theta: number;
+  phi: number;
+  distance: number;
+  eye: Float32Array;
+  up: Float32Array;
+}
+
+declare function createCamera(regl: REGL.Regl, props: Props): REGL.DrawCommand<Context, Props>;

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -8,7 +8,6 @@ module.exports = function stats () {
     textureCount: 0,
     cubeCount: 0,
     renderbufferCount: 0,
-
     maxTextureUnits: 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.1",
   "description": "regl is a fast functional WebGL framework.",
   "main": "dist/regl.js",
+  "types": "dist/regl.d.ts",
   "files": [
     "regl.js",
     "regl.d.ts",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "bench-node": "node bench/bench-node.js",
     "bench-graph": "node bench/bench-graph.js",
     "bench-history": "node bench/bench-history",
-    "build": "npm run build-script && npm run build-min && npm run build-bench && npm run build-compare",
+    "build": "npm run build-script && npm run build-min && npm run build-bench && npm run build-compare && npm run build-typescript",
     "build-script": "rollup -c rollup/config.js",
     "build-min": "rollup -c rollup/config.unchecked.js && node bin/minify.js dist/regl.unchecked.js dist/regl.min.js",
     "build-bench": "rollup -c rollup/config.bench.js",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "scripts": {
     "test": "standard | snazzy && tape test/util/index.js | faucet",
     "test-browser": "budo test/util/browser.js --open",
+    "test-typescript": "tsc",
     "cover": "istanbul cover test/util/index.js",
     "bench-browser": "budo bench/bench.js --open",
     "bench-node": "node bench/bench-node.js",
@@ -104,6 +105,7 @@
     "build-gallery": "node bin/build-gallery.js",
     "build-compare": "node bin/build-compare.js",
     "build-docs": "remark API.md -o API.md",
+    "build-typescript": "cp regl.d.ts dist/",
     "lint-docs": "remark --frail --quiet README.md API.md DEVELOPING.md CHANGES.md"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "tape": "^4.4.0",
     "teapot": "^1.0.0",
     "three": "^0.79.0",
+    "typescript": "^2.7.1",
     "vectorize-text": "^3.0.2",
     "vertices-bounding-box": "^1.0.0"
   },

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -146,13 +146,13 @@ declare namespace REGL {
     renderbuffer(options: REGL.RenderbufferOptions): REGL.Renderbuffer;
 
     /* Creates a Framebuffer of dimensions 1 x 1. */
-    framebuffer(): REGL.Framebuffer;
+    framebuffer(): REGL.Framebuffer2D;
     /* Creates a Framebuffer of dimensions `radius` x `radius`. */
-    framebuffer(radius: number): REGL.Framebuffer;
+    framebuffer(radius: number): REGL.Framebuffer2D;
     /* Creates a Framebuffer of dimensions `width` x `height`. */
-    framebuffer(width: number, height: number): REGL.Framebuffer;
+    framebuffer(width: number, height: number): REGL.Framebuffer2D;
     /* Creates a Framebuffer using creation `options`. */
-    framebuffer(options: REGL.FramebufferOptions): REGL.Framebuffer;
+    framebuffer(options: REGL.FramebufferOptions): REGL.Framebuffer2D;
 
     /* Creates a FramebufferCube whose faces have dimensions 1 x 1. */
     framebufferCube(): REGL.FramebufferCube;
@@ -922,7 +922,9 @@ declare namespace REGL {
     /* `gl.SRGB8_ALPHA8`, requires EXT_sRGB */
     "srgba";
 
-  interface Framebuffer extends Resource {
+  type Framebuffer = Framebuffer2D | FramebufferCube;
+
+  interface Framebuffer2D extends Resource {
     /* Reinitializes the Framebuffer in place using dimensions: 1 x 1. */
     (): void;
     /* Reinitializes the Framebuffer in place using dimensions: `radius` x `radius`. */

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -966,7 +966,13 @@ declare namespace REGL {
     resize(): void;
     resize(radius: number): void;
 
-    subimage(face: REGL.TextureCubeFaceIndexType, data: TextureImageData, x?: number, y?: number, level?: number);
+    subimage(
+      face: REGL.TextureCubeFaceIndexType,
+      data: TextureImageData,
+      x?: number,
+      y?: number,
+      level?: number,
+    ): void;
   }
 
   interface Renderbuffer extends Resource {

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -200,13 +200,13 @@ declare namespace REGL {
   }
 
   interface InitializationOptions {
-    /** A container element which regl inserts a canvas into. (Default document.body) */
-    container?: string | HTMLElement;
-    /** A reference to an HTML canvas element. (Default created and appending to container)*/
-    canvas?: string | HTMLCanvasElement;
     /** A reference to a WebGL rendering context. (Default created from canvas) */
     gl?: WebGLRenderingContext;
-    /** The context creation attributes passed to the WebGL context constructor */
+    /** An HTML canvas element or a selector string to find this element. (Default created and appended to container)*/
+    canvas?: string | HTMLCanvasElement;
+    /** A container element into which regl inserts a canvas or a selector string to find this element. (Default document.body) */
+    container?: string | HTMLElement;
+    /** The context creation attributes passed to the WebGL context constructor. */
     attributes?: WebGLContextAttributes;
     /** A multiplier which is used to scale the canvas size relative to the container. (Default window.devicePixelRatio) */
     pixelRatio?: number;

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -935,7 +935,7 @@ declare namespace REGL {
     destroy(): void;
   }
 
-  interface Buffer extends Resource {
+  interface Buffer extends REGL.Resource {
     /**
      * Wraps a WebGL array buffer object.
      */
@@ -1005,7 +1005,7 @@ declare namespace REGL {
     /** gl.FLOAT */
     "float32" | "float";
 
-  interface Elements extends Resource {
+  interface Elements extends REGL.Resource {
     /**
      * Wraps a WebGL element array buffer object.
      */
@@ -1378,7 +1378,7 @@ declare namespace REGL {
     ];
   }
 
-  interface Renderbuffer extends Resource {
+  interface Renderbuffer extends REGL.Resource {
     readonly stats: {
         /** Size of the renderbuffer in bytes. */
         size: number;
@@ -1420,7 +1420,7 @@ declare namespace REGL {
   }
 
   type RenderbufferFormat =
-    RenderbufferColorFormat |
+    REGL.RenderbufferColorFormat |
     /* `gl.DEPTH_COMPONENT16` */
     "depth" |
     /* `gl.STENCIL_INDEX8` */
@@ -1444,9 +1444,9 @@ declare namespace REGL {
     /* `gl.SRGB8_ALPHA8`, requires EXT_sRGB */
     "srgba";
 
-  type Framebuffer = Framebuffer2D | FramebufferCube;
+  type Framebuffer = REGL.Framebuffer2D | REGL.FramebufferCube;
 
-  interface Framebuffer2D extends Resource {
+  interface Framebuffer2D extends REGL.Resource {
     /* Reinitializes the Framebuffer in place using dimensions: 1 x 1. */
     (): REGL.Framebuffer2D;
     /* Reinitializes the Framebuffer in place using dimensions: `radius` x `radius`. */
@@ -1462,7 +1462,7 @@ declare namespace REGL {
     use<
       Context extends REGL.DefaultContext = REGL.DefaultContext,
       Props extends {} = {}
-    >(body: CommandBodyFn<Context, Props>): void;
+    >(body: REGL.CommandBodyFn<Context, Props>): void;
 
     /* Resizes the Framebuffer and all its attachments. */
     resize(radius: number): REGL.Framebuffer2D;
@@ -1503,7 +1503,7 @@ declare namespace REGL {
 
   type Framebuffer2DAttachment = REGL.Texture2D | REGL.Renderbuffer;
 
-  interface FramebufferCube extends Resource {
+  interface FramebufferCube extends REGL.Resource {
     /* Reinitializes the FramebufferCube in place using face dimensions 1 x 1. */
     (): REGL.FramebufferCube;
     /* Reinitializes the FramebufferCube in place using face dimensions `radius` x `radius`. */

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -847,34 +847,36 @@ declare namespace REGL {
     textureFormats: TextureFormatType[];
   }
 
-  // TODO Revise the types of `REGL.Stats`
   interface Stats {
     /** The number of array buffers currently allocated */
-    bufferCount?: number;
+    bufferCount: number;
     /** The number of element buffers currently allocated */
-    elementsCount?: number;
+    elementsCount: number;
     /** The number of framebuffers currently allocated */
-    framebufferCount?: number;
+    framebufferCount: number;
     /** The number of shaders currently allocated */
-    shaderCount?: number;
+    shaderCount: number;
     /** The number of textures currently allocated */
-    textureCount?: number;
+    textureCount: number;
     /** The number of cube maps currently allocated */
-    cubeCount?: number;
+    cubeCount: number;
     /** The number of renderbuffers currently allocated */
-    renderbufferCount?: number;
-    /** The total amount of memory allocated for textures and cube maps */
-    getTotalTextureSize(): number;
-    /** The total amount of memory allocated for array buffers and element buffers */
-    getTotalBufferSize(): number;
-    /** The total amount of memory allocated for renderbuffers */
-    getTotalRenderbufferSize(): number;
-    /** The maximum number of uniforms in any shader */
-    getMaxUniformsCount(): number;
-    /** The maximum number of attributes in any shader */
-    getMaxAttributesCount(): number;
+    renderbufferCount: number;
     /** The maximum number of texture units used */
     maxTextureUnits: number;
+
+    // The following functions are only available if regl is initialized with option `profile: true`
+
+    /** The total amount of memory allocated for textures and cube maps */
+    getTotalTextureSize?: () => number;
+    /** The total amount of memory allocated for array buffers and element buffers */
+    getTotalBufferSize?: () => number;
+    /** The total amount of memory allocated for renderbuffers */
+    getTotalRenderbufferSize?: () => number;
+    /** The maximum number of uniforms in any shader */
+    getMaxUniformsCount?: () => number;
+    /** The maximum number of attributes in any shader */
+    getMaxAttributesCount?: () => number;
   }
 
   interface CommandStats {

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -795,55 +795,55 @@ declare namespace REGL {
   // TODO Revise the types of `REGL.Limits` fields
   interface Limits {
     /** An array of bits depths for the red, green, blue and alpha channels */
-    colorBits?: [number, number, number, number];
+    colorBits: [number, number, number, number];
     /** Bit depth of drawing buffer */
-    depthBits?: number;
+    depthBits: number;
     /** Bit depth of stencil buffer */
-    stencilBits?: number;
+    stencilBits: number;
     /** gl.SUBPIXEL_BITS */
-    subpixelBits?: any;
+    subpixelBits: any;
     /** A list of all supported extensions */
-    extensions?: string[];
+    extensions: string[];
     /** Maximum number of anisotropic filtering samples */
-    maxAnisotropic?: number;
+    maxAnisotropic: number;
     /** Maximum number of draw buffers */
-    maxDrawbuffers?: number;
+    maxDrawbuffers: number;
     /** Maximum number of color attachments */
-    maxColorAttachments?: number;
+    maxColorAttachments: number;
     /** gl.ALIASED_POINT_SIZE_RANGE */
-    pointSizeDims?: any;
+    pointSizeDims: any;
     /** gl.ALIASED_LINE_WIDTH_RANGE */
-    lineWidthDims?: any;
+    lineWidthDims: any;
     /** gl.MAX_VIEWPORT_DIMS */
-    maxViewportDims?: any;
+    maxViewportDims: any;
     /** gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS */
-    maxCombinedTextureUnits?: any;
+    maxCombinedTextureUnits: any;
     /** gl.MAX_CUBE_MAP_TEXTURE_SIZE */
-    maxCubeMapSize?: any;
+    maxCubeMapSize: any;
     /** gl.MAX_RENDERBUFFER_SIZE */
-    maxRenderbufferSize?: any;
+    maxRenderbufferSize: any;
     /** gl.MAX_TEXTURE_IMAGE_UNITS */
-    maxTextureUnits?: any;
+    maxTextureUnits: any;
     /** gl.MAX_TEXTURE_SIZE */
-    maxTextureSize?: any;
+    maxTextureSize: any;
     /** gl.MAX_VERTEX_ATTRIBS */
-    maxAttributes?: any;
+    maxAttributes: any;
     /** gl.MAX_VERTEX_UNIFORM_VECTORS */
-    maxVertexUniforms?: any;
+    maxVertexUniforms: any;
     /** gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS */
-    maxVertexTextureUnits?: any;
+    maxVertexTextureUnits: any;
     /** gl.MAX_VARYING_VECTORS */
-    maxVaryingVectors?: any;
+    maxVaryingVectors: any;
     /** gl.MAX_FRAGMENT_UNIFORM_VECTORS */
-    maxFragmentUniforms?: any;
+    maxFragmentUniforms: any;
     /** gl.SHADING_LANGUAGE_VERSION */
-    glsl?: string;
+    glsl: string;
     /** gl.RENDERER */
-    renderer?: string;
+    renderer: string;
     /** gl.VENDOR */
-    vendor?: string;
+    vendor: string;
     /** gl.VERSION */
-    version?: string;
+    version: string;
     /** A list of all supported texture formats */
     textureFormats: TextureFormatType[];
   }

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -496,7 +496,7 @@ declare namespace REGL {
      * If `elements` is specified while `primitive`, `count` and `offset` are not,
      * then these values may be inferred from the state of the element array buffer.
      */
-    elements?: REGL.Elements; // TODO number[],
+    elements?: REGL.Elements | ElementsData | ElementsOptions | null;
 
     /* Render target */
 

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -62,12 +62,28 @@ declare function REGL(options: REGL.InitializationOptions): REGL.Regl;
 
 declare namespace REGL {
   /**
-   * Documentation for interface `Regl`.
+   * `Regl` represents the object/function returned from the `REGL` constructor. It exposes the
+   * entire public interface of the `regl` library.
    */
   export interface Regl {
+    /**
+     * The context creation attributes passed to the WebGL context constructor.
+     */
     readonly attributes: WebGLContextAttributes;
+    /**
+     * `regl` is designed in such a way that you should never have to directly access the underlying
+     * WebGL context. However, if you really absolutely need to do this for some reason (for example
+     * to interface with an external library), you can still get a reference to the WebGL context
+     * via the property `_gl`.
+     */
     readonly _gl: WebGLRenderingContext;
+    /**
+     * `regl` exposes info about the WebGL context limits and capabilities via the `limits` object.
+     */
     readonly limits: REGL.Limits;
+    /**
+     * `regl` tracks several metrics for performance monitoring. These can be read using the `stats` object.
+     */
     readonly stats: REGL.Stats;
 
     /**
@@ -120,7 +136,7 @@ declare namespace REGL {
 
     /* Drawing */
 
-    /** Executes an empty draw command */
+    /** Executes an empty draw command. */
     draw(): void;
 
     /* Resource creation */
@@ -206,29 +222,28 @@ declare namespace REGL {
      */
     hasExtension(name: string): boolean;
 
-    /* Poll viewport and timers */
-
     /**
      * Updates the values of internal times and recalculates the size of viewports.
      */
     poll(): void;
-
-    /* Current time */
 
     /**
      * Returns Total time elapsed since regl was initialized in seconds.
      */
     now(): number;
 
-    /* Destruction */
-
     /**
      * Destroys the gl context and releases all associated resources.
      */
     destroy(): void;
 
-    /* Refresh */
-
+    /**
+     * `regl` is designed in such a way that you should never have to directly access the underlying
+     * WebGL context. However, if you really absolutely need to do this for some reason (for example
+     * to interface with an external library), you can still get a reference to the WebGL context
+     * via the property `REGL._gl`. Note, though, that if you have changed the WebGL state, you must
+     * call `_refresh` to restore the `regl` state in order to prevent rendering errors.
+     */
     _refresh(): void;
   }
 
@@ -332,6 +347,10 @@ declare namespace REGL {
   }
 
   /**
+   * Commands can be nested using scoping. If a `DrawCommand` is passed a `CommandBodyFn`, then the
+   * `DrawCommand` is evaluated and its state variables are saved as the defaults for all
+   * `DrawCommand`s invoked within the `CommandBodyFn`.
+   *
    * @param context       REGL context
    * @param props         additional parameters of a draw call
    * @param batchId       index of a command in a batch call
@@ -340,8 +359,9 @@ declare namespace REGL {
     (context: C, props: P, batchId: number) => void;
 
   /**
-   * A *command* is a complete representation of the WebGL state required
-   * to perform some draw call.
+   * Draw commands are the fundamental abstraction in regl. A draw command wraps up all of the WebGL
+   * state associated with a draw call (either drawArrays or drawElements) and packages it into a
+   * single reusable function.
    */
   interface DrawCommand {
     readonly stats: REGL.CommandStats;
@@ -671,8 +691,8 @@ declare namespace REGL {
   }
 
   /*
-    * Resources
-    */
+   * Resources
+   */
 
   /**
    * A *resource* is a handle to a GPU resident object, like a texture, FBO or buffer.

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -597,7 +597,6 @@ declare namespace REGL {
     face?: REGL.FaceOrientationType;
   }
 
-
   interface SamplingOptions {
     /** Toggles `gl.enable(gl.SAMPLE_COVERAGE)` */
     enable?: boolean;

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -1269,6 +1269,7 @@ declare namespace REGL {
   type TextureImageData =
     number[] |
     number[][] |
+    number[][][] |
     ArrayBufferView |
     REGL.NDArrayLike |
     HTMLImageElement |

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -485,10 +485,13 @@ declare namespace REGL {
      * then these values may be inferred from the state of the element array buffer.
      */
     elements?: REGL.Elements; // TODO number[],
+
     /* Render target */
 
     /**
-     * A framebuffer to be used as a target for drawing.
+     * A framebuffer to be used as a target for drawing. (Default: `null`)
+     * Passing null sets the framebuffer to the drawing buffer.
+     * Updating the render target will modify the viewport.
      *
      * Related WebGL APIs
      *
@@ -497,7 +500,11 @@ declare namespace REGL {
     framebuffer?: REGL.Framebuffer | null;
 
     /* Profiling */
-    /** If set, turns on profiling for this command. (Default: `false`) */
+
+    /**
+     * If set, turns on profiling for this command. (Default: `false`)
+     * Profiling stats can be accessed via the `stats` property of the `DrawCommand`.
+     */
     profile?: boolean;
 
     /* Depth buffer */
@@ -661,10 +668,14 @@ declare namespace REGL {
   }
 
   interface DepthTestOptions {
+    /* Toggles gl.enable(gl.DEPTH_TEST). Default: true */
     enable?: boolean;
+    /* Sets `gl.depthMask`. Default: true */
     mask?: boolean;
-    func?: REGL.ComparisonOperatorType;
+    /* Sets `gl.depthRange`. Default: [0, 1] */
     range?: [number, number];
+    /* Sets `gl.depthFunc`. Default: 'less' */
+    func?: REGL.ComparisonOperatorType;
   }
 
   interface BlendingOptions {
@@ -1214,11 +1225,17 @@ declare namespace REGL {
   interface CommandStats {
     /** The number of times the command has been called. */
     count: number;
-    /** The cumulative CPU time spent executing the command in milliseconds. */
+    /**
+     * The cumulative CPU time spent executing the command in milliseconds.
+     * `cpuTime` uses `performance.now` if available. Otherwise it falls back to `Date.now`.
+     */
     cpuTime: number;
     /**
-     * The cumulative GPU time spent executing the command in milliseconds
+     * The cumulative GPU time spent executing the command in milliseconds.
      * (requires the `EXT_disjoint_timer_query` extension).
+     * GPU timer queries update asynchronously. If you are not using `regl.frame()` to tick your
+     * application, then you should periodically call `regl.poll()` each frame to update the timer
+     * statistics.
      */
     gpuTime: number;
   }

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -91,13 +91,13 @@ declare namespace REGL {
      * will set a WebGL state machine to a specified `state`.
      */
     <
-      ParentContext extends REGL.DefaultContext = REGL.DefaultContext,
-      OwnContext extends {} = {},
-      Props extends {} = {},
       Uniforms extends {} = {},
-      Attributes extends {} = {}
+      Attributes extends {} = {},
+      Props extends {} = {},
+      OwnContext extends {} = {},
+      ParentContext extends REGL.DefaultContext = REGL.DefaultContext
     >(
-      drawConfig: REGL.DrawConfig<ParentContext, OwnContext, Props, Uniforms, Attributes>,
+      drawConfig: REGL.DrawConfig<Uniforms, Attributes, Props, OwnContext, ParentContext>,
     ): REGL.DrawCommand<ParentContext & OwnContext, Props>;
 
     /**
@@ -424,11 +424,11 @@ declare namespace REGL {
   }
 
   interface DrawConfig<
-    ParentContext extends REGL.DefaultContext = REGL.DefaultContext,
-    OwnContext extends {} = {},
-    Props extends {} = {},
     Uniforms extends {} = {},
-    Attributes extends {} = {}
+    Attributes extends {} = {},
+    Props extends {} = {},
+    OwnContext extends {} = {},
+    ParentContext extends REGL.DefaultContext = REGL.DefaultContext
   > {
 
     /* Shaders */

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -678,6 +678,24 @@ declare namespace REGL {
     func?: REGL.ComparisonOperatorType;
   }
 
+  type ComparisonOperatorType =
+    /* `gl.NEVER` */
+    "never" |
+    /* `gl.ALWAYS` */
+    "always" |
+    /* `gl.LESS` */
+    "less" | "<" |
+    /* `gl.LEQUAL` */
+    "lequal" | "<=" |
+    /* `gl.GREATER` */
+    "greater" | ">" |
+    /* `gl.GEQUAL` */
+    "gequal" | ">=" |
+    /* `gl.EQUAL` */
+    "equal" | "=" |
+    /* `gl.NOTEQUAL` */
+    "notequal" | "!=";
+
   interface BlendingOptions {
     enable?: boolean;
     func?: {
@@ -692,6 +710,30 @@ declare namespace REGL {
     };
     color?: [number, number, number, number];
   }
+
+  type BlendingEquationType =
+    "add" |
+    "subtract" |
+    "reverse subtract" |
+    "min" |
+    "max";
+
+  type BlendingFunctionType =
+    "zero" | 0 |
+    "one" | 1 |
+    "src color" |
+    "one minus src color" |
+    "src alpha" |
+    "one minus src alpha" |
+    "dst color" |
+    "one minus dst color" |
+    "dst alpha" |
+    "one minus dst alpha" |
+    "constant color" |
+    "one minus constant color" |
+    "constant alpha" |
+    "one minus constant alpha" |
+    "src alpha saturate";
 
   interface StencilOptions {
     enable?: boolean;
@@ -714,6 +756,16 @@ declare namespace REGL {
     zpass: REGL.StencilOperationType;
   }
 
+  type StencilOperationType =
+    "zero" |
+    "keep" |
+    "replace" |
+    "invert" |
+    "increment" |
+    "decrement" |
+    "increment wrap" |
+    "decrement wrap";
+
   interface PolygonOffsetOptions {
     enable?: boolean;
     offset: {
@@ -726,6 +778,14 @@ declare namespace REGL {
     enable?: boolean;
     face?: REGL.FaceOrientationType;
   }
+
+  type FaceOrientationType =
+    "front" |
+    "back";
+
+  type FaceWindingType =
+    "cw" |
+    "ccw";
 
   interface SamplingOptions {
     /** Toggles `gl.enable(gl.SAMPLE_COVERAGE)` */
@@ -885,6 +945,98 @@ declare namespace REGL {
     "uint16" |
     "uint32";
 
+  interface Texture extends Resource {
+    readonly stats: {
+        /** Size of the texture, in bytes. */
+        size: number;
+    }
+
+    /** Width of texture. */
+    readonly width: number;
+    /** Height of texture. */
+    readonly height: number;
+    /** Texture format. */
+    readonly format: REGL.TextureFormatType;
+    /** Texture data type. */
+    readonly type: REGL.TextureDataType;
+    /** Texture magnification filter. */
+    readonly mag: REGL.TextureMagFilterType;
+    /** Texture minification filter. */
+    readonly min: REGL.TextureMinFilterType;
+    /** Texture wrap mode on S axis. */
+    readonly wrapS: REGL.TextureWrapModeType;
+    /** Texture wrap mode on T axis. */
+    readonly wrapT: REGL.TextureWrapModeType;
+  }
+
+  type TextureFormatType =
+    "alpha" |
+    "luminance" |
+    "luminance alpha" |
+    "rgb" |
+    "rgba" |
+    "rgba4" |
+    "rgb5 a1" |
+    "rgb565" |
+    "srgb" |
+    "srgba" |
+    "depth" |
+    "depth stencil" |
+    "rgb s3tc dxt1" |
+    "rgba s3tc dxt1" |
+    "rgba s3tc dxt3" |
+    "rgba s3tc dxt5" |
+    "rgb atc" |
+    "rgba atc explicit alpha" |
+    "rgba atc interpolated alpha" |
+    "rgb pvrtc 4bppv1" |
+    "rgb pvrtc 2bppv1" |
+    "rgba pvrtc 4bppv1" |
+    "rgba pvrtc 2bppv1" |
+    "rgb etc1";
+
+  type TextureDataType =
+    "uint8" |
+    "uint16" |
+    "uint32" |
+    "float" |
+    "half float";
+
+  type TextureMagFilterType =
+    "nearest" |
+    "linear";
+
+  type TextureMinFilterType =
+    "nearest" |
+    "linear" |
+    "linear mipmap linear" | "mipmap" |
+    "nearest mipmap linear" |
+    "linear mipmap nearest" |
+    "nearest mipmap nearest";
+
+  type TextureWrapModeType =
+    "repeat" |
+    "clamp" |
+    "mirror";
+
+  interface Texture2D extends Texture {
+    /** Reinitializes the texture. */
+    (data: Texture2DOptions): void;
+
+    /**
+     * Replaces the part of texture with new data.
+     *
+     * @param data      image data object, similar to arguments for the texture constructor
+     * @param x         horizontal offset of the image within the texture (Default: `0`)
+     * @param y         vertical offset of the image within the texture (Default: `0`)
+     * @param level     mipmap level of the texture to modify (Default: `0`)
+     */
+    subimage(data: Texture2DOptions, x?: number, y?: number, level?: number): void;
+
+    /** Resizes a texture. */
+    resize(width?: number, height?: number): void;
+  }
+
   interface Texture2DOptions {
     /** Sets `width`, `height` and, optionally, `channels`. */
     shape?: [number, number] | [number, number, REGL.TextureChannelsType];
@@ -911,56 +1063,17 @@ declare namespace REGL {
     channels?: REGL.TextureChannelsType;
   }
 
-  interface Texture extends Resource {
-    readonly stats: {
-        /** Size of the texture, in bytes. */
-        size: number;
-    }
+  type TextureMipmapHintType =
+    "don't care" | "dont care" |
+    "nice" |
+    "fast";
 
-    /** Width of texture. */
-    readonly width: number;
-    /** Height of texture. */
-    readonly height: number;
-    /** Texture format. */
-    readonly format: REGL.TextureFormatType;
-    /** Texture data type. */
-    readonly type: REGL.TextureDataType;
-    /** Texture magnification filter. */
-    readonly mag: REGL.TextureMagFilterType;
-    /** Texture minification filter. */
-    readonly min: REGL.TextureMinFilterType;
-    /** Texture wrap mode on S axis. */
-    readonly wrapS: REGL.TextureWrapModeType;
-    /** Texture wrap mode on T axis. */
-    readonly wrapT: REGL.TextureWrapModeType;
-  }
+  type TextureColorSpaceType =
+    "none" | "browser";
 
-  interface Texture2D extends Texture {
-    /** Reinitializes the texture. */
-    (data: Texture2DOptions): void;
+  type TextureChannelsType = 1 | 2 | 3 | 4;
 
-    /**
-     * Replaces the part of texture with new data.
-     *
-     * @param data      image data object, similar to arguments for the texture constructor
-     * @param x         horizontal offset of the image within the texture (Default: `0`)
-     * @param y         vertical offset of the image within the texture (Default: `0`)
-     * @param level     mipmap level of the texture to modify (Default: `0`)
-     */
-    subimage(data: Texture2DOptions, x?: number, y?: number, level?: number): void;
-
-    /** Resizes a texture. */
-    resize(width?: number, height?: number): void;
-  }
-
-  interface TextureCubeOptions {
-    radius?: number;
-    faces?: [
-        TextureImageData, TextureImageData,
-        TextureImageData, TextureImageData,
-        TextureImageData, TextureImageData
-    ];
-  }
+  type TextureUnpackAlignmentType = 1 | 2 | 4 | 8;
 
   interface TextureCube extends Texture {
     resize(): void;
@@ -973,6 +1086,17 @@ declare namespace REGL {
       y?: number,
       level?: number,
     ): void;
+  }
+
+  type TextureCubeFaceIndexType = 0 | 1 | 2 | 3 | 4 | 5;
+
+  interface TextureCubeOptions {
+    radius?: number;
+    faces?: [
+      TextureImageData, TextureImageData,
+      TextureImageData, TextureImageData,
+      TextureImageData, TextureImageData
+    ];
   }
 
   interface Renderbuffer extends Resource {
@@ -1246,58 +1370,6 @@ declare namespace REGL {
     gpuTime: number;
   }
 
-  type ComparisonOperatorType =
-    "never" |
-    "always" |
-    "less" | "<" |
-    "lequal" | "<=" |
-    "greater" | ">" |
-    "gequal" | ">=" |
-    "equal" | "=" |
-    "notequal" | "!=";
-
-  type BlendingEquationType =
-    "add" |
-    "subtract" |
-    "reverse subtract" |
-    "min" |
-    "max";
-
-  type BlendingFunctionType =
-    "zero" | 0 |
-    "one" | 1 |
-    "src color" |
-    "one minus src color" |
-    "src alpha" |
-    "one minus src alpha" |
-    "dst color" |
-    "one minus dst color" |
-    "dst alpha" |
-    "one minus dst alpha" |
-    "constant color" |
-    "one minus constant color" |
-    "constant alpha" |
-    "one minus constant alpha" |
-    "src alpha saturate";
-
-  type StencilOperationType =
-    "zero" |
-    "keep" |
-    "replace" |
-    "invert" |
-    "increment" |
-    "decrement" |
-    "increment wrap" |
-    "decrement wrap";
-
-  type FaceOrientationType =
-    "front" |
-    "back";
-
-  type FaceWindingType =
-    "cw" |
-    "ccw";
-
   // TODO Cover all possible things that could be used to create/update a texture
   // Possible candidates: HTMLImageElement, HTMLVideoElement, NDArray,
   // various typed arrays and (unflattened) JS arrays.
@@ -1310,70 +1382,6 @@ declare namespace REGL {
     CanvasRenderingContext2D |
     HTMLVideoElement |
     REGL.NDArray;
-
-  type TextureFormatType =
-    "alpha" |
-    "luminance" |
-    "luminance alpha" |
-    "rgb" |
-    "rgba" |
-    "rgba4" |
-    "rgb5 a1" |
-    "rgb565" |
-    "srgb" |
-    "srgba" |
-    "depth" |
-    "depth stencil" |
-    "rgb s3tc dxt1" |
-    "rgba s3tc dxt1" |
-    "rgba s3tc dxt3" |
-    "rgba s3tc dxt5" |
-    "rgb atc" |
-    "rgba atc explicit alpha" |
-    "rgba atc interpolated alpha" |
-    "rgb pvrtc 4bppv1" |
-    "rgb pvrtc 2bppv1" |
-    "rgba pvrtc 4bppv1" |
-    "rgba pvrtc 2bppv1" |
-    "rgb etc1";
-
-  type TextureDataType =
-    "uint8" |
-    "uint16" |
-    "uint32" |
-    "float" |
-    "half float";
-
-  type TextureMagFilterType =
-    "nearest" |
-    "linear";
-
-  type TextureMinFilterType =
-    "nearest" |
-    "linear" |
-    "linear mipmap linear" | "mipmap" |
-    "nearest mipmap linear" |
-    "linear mipmap nearest" |
-    "nearest mipmap nearest";
-
-  type TextureMipmapHintType =
-    "don't care" | "dont care" |
-    "nice" |
-    "fast";
-
-  type TextureColorSpaceType =
-    "none" | "browser";
-
-  type TextureWrapModeType =
-    "repeat" |
-    "clamp" |
-    "mirror";
-
-  type TextureChannelsType = 1 | 2 | 3 | 4;
-
-  type TextureUnpackAlignmentType = 1 | 2 | 4 | 8;
-
-  type TextureCubeFaceIndexType = 0 | 1 | 2 | 3 | 4 | 5;
 
   /**
    * An N-dimensional array, as per `ndarray` module.

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -919,7 +919,13 @@ declare namespace REGL {
    * A *resource* is a handle to a GPU resident object, like a texture, FBO or buffer.
    */
   interface Resource {
-    /** relevant WebGL API: `gl.deleteBuffer` */
+    /**
+     * relevant WebGL APIs:
+     * - `gl.deleteBuffer`
+     * - `gl.deleteTexture`
+     * - `gl.deleteRenderbuffer`
+     * - `gl.deleteFramebuffer`
+     */
     destroy(): void;
   }
 

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -161,14 +161,15 @@ declare namespace REGL {
     /* Creates an Elements object using creation `options`. */
     elements(options: REGL.ElementsOptions): REGL.Elements;
 
-    /**
-     * Creates an empty texture with given dimensions.
-     *
-     * @param width     width of a texture, in pixels (Default: `1`)
-     * @param height    height of a texture, in pixels (Default: equal to `width`)
-     */
-    texture(width?: number, height?: number): REGL.Texture2D;
+    /* Creates a 2D Texture of dimensions 1 x 1. */
+    texture(): REGL.Texture2D;
+    /* Creates a 2D Texture of dimensions `radius` x `radius`. */
+    texture(radius: number): REGL.Texture2D;
+    /* Creates a 2D Texture of dimensions `width` x `height`. */
+    texture(width: number, height: number): REGL.Texture2D;
+    /* Creates a 2D Texture using the provided `data`. */
     texture(data: REGL.TextureImageData): REGL.Texture2D;
+    /* Creates a 2D Texture using creation `options`. */
     texture(options: REGL.Texture2DOptions): REGL.Texture2D;
 
     cube(radius?: number): REGL.TextureCube;
@@ -1062,8 +1063,16 @@ declare namespace REGL {
     "mirror";
 
   interface Texture2D extends Texture {
-    /** Reinitializes the texture. */
-    (data: Texture2DOptions): void;
+    /* Reinitializes the texture in place with dimensions 1 x 1. */
+    (): void;
+    /* Reinitializes the texture in place with dimensions `radius` x `radius`. */
+    (radius: number): void;
+    /* Reinitializes the texture in place with dimensions `width` x `height`. */
+    (width: number, height: number): void;
+    /* Reinitializes the texture in place using the provided `data`. */
+    (data: REGL.TextureImageData): void;
+    /* Reinitializes the texture in place using creation `options`. */
+    (options: REGL.Texture2DOptions): void;
 
     /**
      * Replaces the part of texture with new data.
@@ -1073,36 +1082,97 @@ declare namespace REGL {
      * @param y         vertical offset of the image within the texture (Default: `0`)
      * @param level     mipmap level of the texture to modify (Default: `0`)
      */
-    subimage(data: Texture2DOptions, x?: number, y?: number, level?: number): void;
+    /* Replaces the area at offset `x` (default: 0), `y` (default: 0), with `data`. */
+    subimage(data: REGL.TextureImageData, x?: number, y?: number, level?: number): void;
+    /* Replaces a subset of the image using creation `options`. */
+    subimage(options: Texture2DOptions): void;
 
-    /** Resizes a texture. */
-    resize(width?: number, height?: number): void;
+    /** Resizes the texture to `radius` x `radius`. */
+    resize(radius: number): void;
+    /** Resizes the texture to dimensions `width` x `height`. */
+    resize(width: number, height: number): void;
   }
 
   interface Texture2DOptions {
-    /** Sets `width`, `height` and, optionally, `channels`. */
+    /* Sets `width`, `height` and, optionally, `channels`. */
     shape?: [number, number] | [number, number, REGL.TextureChannelsType];
-    /** Sets equal `width` and `height`. */
+    /* Sets both width and height to the same value. */
     radius?: number;
+    /* Width of texture. Default: 0 */
     width?: number;
+    /* Height of texture. Default: 0 */
     height?: number;
+    /**
+     * Sets the number of color channels for the texture format.
+     * It can be used as an alternative to `format`.
+     * Default: null
+     */
+    channels?: REGL.TextureChannelsType | null;
+    /* Image data for the texture. Default: null */
+    data?: REGL.TextureImageData | null;
 
-    data?: REGL.TextureImageData;
-
+    /* Sets magnification filter. Default: 'nearest' */
     mag?: REGL.TextureMagFilterType;
+    /* Sets minification filter. Default: 'nearest' */
     min?: REGL.TextureMinFilterType;
+    /* Sets wrap mode for both axes, either to the same value, or independently, `[wrapS, wrapT]` */
+    wrap?: REGL.TextureWrapModeType | [REGL.TextureWrapModeType, REGL.TextureWrapModeType];
+    /* Sets wrap mode on S axis. Default: 'clamp' */
     wrapS?: REGL.TextureWrapModeType;
+    /* Sets wrap mode on T axis. Default: 'clamp' */
     wrapT?: REGL.TextureWrapModeType;
+    /* Sets number of anisotropic samples; requires `EXT_texture_filter_anisotropic`. Default: 0 */
     aniso?: number;
+    /* Determines the format of the texture and possibly also the type. Default: 'rgba' */
+    format?: REGL.TextureFormatType;
+    /**
+     * Texture type.
+     * In many cases type can be inferred from the format and other information in the texture.
+     * However, in some situations it may still be necessary to set it manually.
+     * Default: 'uint8'
+     */
     type?: REGL.TextureDataType;
 
-    mipmap?: REGL.TextureMipmapHintType;
+    /**
+     * If boolean, then it sets whether or not we should regenerate the mipmaps.
+     *
+     * If a string, it allows you to specify a hint to the mipmap generator.
+     * If a hint is specified, then also the mipmaps will be regenerated.
+     *
+     * Finally, mipmap can also be an array of arrays. In this case, every subarray will be one of
+     * the mipmaps, and you can thus use this option to manually specify the mipmaps of the image.
+     *
+     * Default: false
+     */
+    mipmap?: boolean | REGL.TextureMipmapHintType | number[][];
+    /* Flips textures vertically when uploading. Default: false */
     flipY?: boolean;
-    alignment?: number;
+    /* Sets unpack alignment per row. Default: 1 */
+    alignment?: REGL.TextureUnpackAlignmentType;
+    /* Premultiply alpha when unpacking. Default: false */
     premultiplyAlpha?: boolean;
+    /* Sets the WebGL color space flag for pixel unpacking. Default: 'none' */
     colorSpace?: REGL.TextureColorSpaceType;
-    unpackAlignment?: REGL.TextureUnpackAlignmentType;
-    channels?: REGL.TextureChannelsType;
+  }
+
+  type TextureImageData =
+    number[] |
+    number[][] |
+    ArrayBufferView |
+    REGL.NDArrayLike |
+    HTMLImageElement |
+    HTMLVideoElement |
+    HTMLCanvasElement |
+    CanvasRenderingContext2D;
+
+  /**
+   * An N-dimensional array, as per `scijs/ndarray`.
+   */
+  interface NDArrayLike {
+    shape: number[];
+    stride: number[];
+    offset: number;
+    data: number[] | ArrayBufferView;
   }
 
   type TextureMipmapHintType =
@@ -1425,33 +1495,5 @@ declare namespace REGL {
      * statistics.
      */
     gpuTime: number;
-  }
-
-  // TODO Cover all possible things that could be used to create/update a texture
-  // Possible candidates: HTMLImageElement, HTMLVideoElement, NDArray,
-  // various typed arrays and (unflattened) JS arrays.
-  type TextureImageData =
-    number[] |
-    number[][] |
-    ArrayBufferView |
-    HTMLImageElement |
-    HTMLCanvasElement |
-    CanvasRenderingContext2D |
-    HTMLVideoElement |
-    REGL.NDArray;
-
-  /**
-   * An N-dimensional array, as per `ndarray` module.
-   *
-   * More detailed typing does not belong here, so we assume
-   * anything with `shape`, `stride`, `offset` and `data` is ok.
-   *
-   * TODO Reuse typings from `ndarray` module
-   */
-  interface NDArray {
-    shape: any;
-    stride: any;
-    offset: any;
-    data: any;
   }
 }

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -1208,8 +1208,13 @@ declare namespace REGL {
      * Default: null
      */
     channels?: REGL.TextureChannelsType | null;
+    /**
+     * The following properties, `data` and `copy` are mutually exclusive.
+     */
     /* Image data for the texture. Default: null */
     data?: REGL.TextureImageData | null;
+    /* Create texture by copying the pixels in the current frame buffer. Default: false */
+    copy?: boolean;
 
     /* Sets magnification filter. Default: 'nearest' */
     mag?: REGL.TextureMagFilterType;

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -419,8 +419,10 @@ declare namespace REGL {
     (body?: REGL.CommandBodyFn<Context, Props>): void;
     /** Run a command `count` times. */
     (count: number, body?: REGL.CommandBodyFn<Context, Props>): void;
+    /** Run a command with props. */
+    (props: Partial<Props>, body?: REGL.CommandBodyFn<Context, Props>): void;
     /** Run a command batch. */
-    (props: Partial<Props> | Array<Partial<Props>>, body?: REGL.CommandBodyFn<Context, Props>): void;
+    (props: Array<Partial<Props>>, body?: REGL.CommandBodyFn<Context, Props>): void;
   }
 
   interface DrawConfig<

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -76,7 +76,11 @@ declare namespace REGL {
      */
     (state: REGL.State): REGL.Command;
 
-    /** Clears selected buffers to specified values. */
+    /**
+     * Clears selected buffers to specified values.
+     * If an option is not present, then the corresponding buffer is not cleared.
+     * Relevant WebGL API: `gl.clear`
+     */
     clear(options: REGL.ClearOptions): void;
 
     /* Reading pixels */
@@ -269,13 +273,25 @@ declare namespace REGL {
   type DynamicVariableFn = (context: REGL.Context, props: REGL.Props, batchId: number) => PropType;
 
   interface ClearOptions {
-    /** Specify the red, green, blue, and alpha values used when the color buffers are cleared. The initial values are all `0.0`. */
+    /**
+     * RGBA values (range 0-1) to use when the color buffer is cleared. Initial value: [0, 0, 0, 0].
+     * Relevant WebGL API: `gl.clearColor`
+     */
     color?: [number, number, number, number];
-    /** Specifies the depth value used when the depth buffer is cleared. The initial value is `1.0`. */
+    /**
+     * Depth value (range 0-1) to use when the depth buffer is cleared. Initial value: 1.
+     * Relevant WebGL API: `gl.clearDepth`
+     */
     depth?: number;
-    /** Specifies the index used when the stencil buffer is cleared. The initial value is `0`. */
+    /**
+     * The index used when the stencil buffer is cleared. Initial value: 0.
+     * Relevant WebGL API: `gl.clearStencil`
+     */
     stencil?: number;
-    /** Sets the target framebuffer to clear (if unspecified, uses the current framebuffer object). */
+    /**
+     * Sets the target framebuffer to clear (if unspecified, uses the current framebuffer object).
+     * Relevant WebGL API: `gl.bindFrameBuffer`
+     */
     framebuffer?: REGL.Framebuffer | null;
   }
 

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -90,7 +90,7 @@ declare namespace REGL {
      * Creates a new REGL command. The resulting command, when executed,
      * will set a WebGL state machine to a specified `state`.
      */
-    (state: REGL.DrawConfig): REGL.DrawCommand;
+    (drawConfig: REGL.DrawConfig): REGL.DrawCommand;
 
     /**
      * Clears selected buffers to specified values.

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -98,9 +98,9 @@ declare namespace REGL {
 
     /* Dynamic variable binding */
 
-    prop(name: string): REGL.DynamicVariable;
-    context(name: string): REGL.DynamicVariable;
-    this(name: string): REGL.DynamicVariable;
+    prop(name: string): REGL.DynamicPropVariable;
+    context(name: string): REGL.DynamicContextVariable;
+    this(name: string): REGL.DynamicStateVariable;
 
     /* Drawing */
 
@@ -240,13 +240,23 @@ declare namespace REGL {
     cancel(): void;
   }
 
-  type DynamicVariable = {
-    // This type is supposed to be opaque.
-    "Dynamic Variable": void;
+  interface DynamicVariable {
+    /** This type is supposed to be opaque. Properties are listed only because TS casts _anything_ to `DynamicVariable`. */
+    readonly id: number;
+    readonly type: number;
+    readonly data: string;
+  }
 
-    // Properties are listed only because TS casts _anything_ to `DynamicVariable`.
-    // readonly id: number;
-    // readonly type: T;
+  interface DynamicPropVariable extends REGL.DynamicVariable {
+    readonly type: 1;
+  }
+
+  interface DynamicContextVariable extends REGL.DynamicVariable {
+    readonly type: 2;
+  }
+
+  interface DynamicStateVariable extends REGL.DynamicVariable {
+    readonly type: 3;
   }
 
   type DynamicVariableFn = (context: REGL.Context, props: REGL.Props, batchId: number) => PropType;

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -567,41 +567,37 @@ declare namespace REGL {
 
     /* Front face */
 
+    /* Sets gl.frontFace. Default: 'ccw' */
     frontFace?: REGL.FaceWindingType;
 
     /* Dithering */
 
+    /* Toggles `gl.DITHER`. Default: false */
     dither?: boolean;
 
     /* Line width */
 
+    /* Sets `gl.lineWidth`. Default: 1 */
     lineWidth?: number;
 
     /* Color mask */
 
-    /**
-     * - [gl.colorMask](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glColorMask.xml)
-     */
+    /* Sets `gl.colorMask`. Default: [true, true, true, true] */
     colorMask?: [boolean, boolean, boolean, boolean];
 
     /* Sample coverage */
 
-    /**
-     * - [gl.sampleCoverage](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glSampleCoverage.xml)
-     */
     sample?: REGL.SamplingOptions;
 
     /* Scissor */
 
-    /**
-     * - [gl.scissor](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glScissor.xml)
-     */
     scissor?: REGL.ScissorOptions;
 
     /* Viewport */
 
     /**
-     * - [gl.viewport](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glViewport.xml)
+     * Sets `gl.viewport`. Default: {}
+     * Updating `viewport` will modify the context variables `viewportWidth` and `viewportHeight`.
      */
     viewport?: REGL.BoundingBox;
   }
@@ -680,7 +676,7 @@ declare namespace REGL {
   }
 
   interface DepthTestOptions {
-    /* Toggles gl.enable(gl.DEPTH_TEST). Default: true */
+    /* Toggles `gl.enable(gl.DEPTH_TEST)`. Default: true */
     enable?: boolean;
     /* Sets `gl.depthMask`. Default: true */
     mask?: boolean;
@@ -858,22 +854,28 @@ declare namespace REGL {
   }
 
   interface CullingOptions {
+    /* Toggles `gl.enable(gl.CULL_FACE)`. Default: false */
     enable?: boolean;
+    /* Sets `gl.cullFace`. Default: 'back' */
     face?: REGL.FaceOrientationType;
   }
 
   type FaceOrientationType =
+    /* `gl.FRONT` */
     "front" |
+    /* `gl.BACK` */
     "back";
 
   type FaceWindingType =
+    /* `gl.CW` */
     "cw" |
+    /* `gl.CCW` */
     "ccw";
 
   interface SamplingOptions {
-    /** Toggles `gl.enable(gl.SAMPLE_COVERAGE)` */
+    /** Toggles `gl.enable(gl.SAMPLE_COVERAGE)`. Default: false */
     enable?: boolean;
-    /** Toggles `gl.enable(gl.SAMPLE_ALPHA_TO_COVERAGE)` */
+    /** Toggles `gl.enable(gl.SAMPLE_ALPHA_TO_COVERAGE)`. Default: false */
     alpha?: boolean;
     /** Sets `gl.sampleCoverage`. Default: { value: 1, invert: false } */
     coverage?: REGL.SampleCoverage;

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -357,7 +357,7 @@ declare namespace REGL {
      * RGBA values (range 0-1) to use when the color buffer is cleared. Initial value: [0, 0, 0, 0].
      * Relevant WebGL API: `gl.clearColor`
      */
-    color?: [number, number, number, number];
+    color?: REGL.Vec4;
     /**
      * Depth value (range 0-1) to use when the depth buffer is cleared. Initial value: 1.
      * Relevant WebGL API: `gl.clearDepth`
@@ -594,7 +594,7 @@ declare namespace REGL {
     /* Color mask */
 
     /* Sets `gl.colorMask`. Default: [true, true, true, true] */
-    colorMask?: MaybeDynamic<[boolean, boolean, boolean, boolean], ParentContext & OwnContext, Props>;
+    colorMask?: MaybeDynamic<REGL.BVec4, ParentContext & OwnContext, Props>;
 
     /* Sample coverage */
 
@@ -731,7 +731,7 @@ declare namespace REGL {
      */
     func?: REGL.BlendingFunctionCombined | REGL.BlendingFunctionSeparate;
     /* Sets `gl.blendColor` */
-    color?: [number, number, number, number];
+    color?: REGL.Vec4;
   }
 
   interface BlendingEquationSeparate {
@@ -1656,4 +1656,48 @@ declare namespace REGL {
      */
     gpuTime: number;
   }
+
+  /**
+   * The following types are defined for the convenience of clients of this library. They represent
+   * the most likely forms in which values being passed to shaders (via uniforms and attributes) are
+   * defined: flat JS arrays for vectors and either flat or two-dimensional JS arrays for matrices.
+   */
+
+  type Vec2 = [number, number];
+  type Vec3 = [number, number, number];
+  type Vec4 = [number, number, number, number];
+
+  type BVec2 = [boolean, boolean];
+  type BVec3 = [boolean, boolean, boolean];
+  type BVec4 = [boolean, boolean, boolean, boolean];
+
+  type Mat2 = [
+    number, number,
+    number, number
+  ] | [
+    REGL.Vec2,
+    REGL.Vec2
+  ];
+
+  type Mat3 = [
+    number, number, number,
+    number, number, number,
+    number, number, number
+  ] | [
+    REGL.Vec3,
+    REGL.Vec3,
+    REGL.Vec3
+  ];
+
+  type Mat4 = [
+    number, number, number, number,
+    number, number, number, number,
+    number, number, number, number,
+    number, number, number, number
+  ] | [
+    REGL.Vec4,
+    REGL.Vec4,
+    REGL.Vec4,
+    REGL.Vec4
+  ];
 }

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -1359,7 +1359,7 @@ declare namespace REGL {
 
   interface TextureCubeOptions extends Texture2DOptions {
     /* Uses the provided texture data for the six faces. */
-    faces: [
+    faces?: [
       TextureImageData, TextureImageData,
       TextureImageData, TextureImageData,
       TextureImageData, TextureImageData

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -947,7 +947,7 @@ declare namespace REGL {
 
   interface Texture extends Resource {
     readonly stats: {
-        /** Size of the texture, in bytes. */
+        /** Size of the texture in bytes. */
         size: number;
     }
 
@@ -970,53 +970,95 @@ declare namespace REGL {
   }
 
   type TextureFormatType =
+    /* `gl.ALPHA`; channels: 1; types: 'uint8', 'half float', 'float' */
     "alpha" |
+    /* `gl.LUMINANCE`; channels: 1; types: 'uint8', 'half float', 'float' */
     "luminance" |
+    /* `gl.LUMINANCE_ALPHA`; channels: 2; types: 'uint8', 'half float', 'float' */
     "luminance alpha" |
+    /* `gl.RGB`; channels: 3; types: 'uint8', 'half float', 'float' */
     "rgb" |
+    /* `gl.RGBA`; channels: 4; types: 'uint8', 'half float', 'float' */
     "rgba" |
+    /* `gl.RGBA4`; channels: 4; types: 'rgba4' */
     "rgba4" |
+    /* `gl.RGB5_A1`; channels: 4; types: 'rgba5 a1' */
     "rgb5 a1" |
+    /* `gl.RGB565`; channels: 3; types: 'rgb565' */
     "rgb565" |
+    /* `ext.SRGB`; channels: 3; types: 'uint8', 'half float', 'float' */
     "srgb" |
+    /* `ext.RGBA`; channels: 4; types: 'uint8', 'half float', 'float' */
     "srgba" |
+    /* `gl.DEPTH_COMPONENT`; channels: 1; types: 'uint16', 'uint32' */
     "depth" |
+    /* `gl.DEPTH_STENCIL`; channels: 2; 'depth stencil' */
     "depth stencil" |
+    /* `ext.COMPRESSED_RGB_S3TC_DXT1_EXT`; channels: 3; types: 'uint8' */
     "rgb s3tc dxt1" |
+    /* `ext.COMPRESSED_RGBA_S3TC_DXT1_EXT`; channels: 4; types: 'uint8' */
     "rgba s3tc dxt1" |
+    /* `ext.COMPRESSED_RGBA_S3TC_DXT3_EXT`; channels: 4; types: 'uint8' */
     "rgba s3tc dxt3" |
+    /* `ext.COMPRESSED_RGBA_S3TC_DXT5_EXT`; channels: 4; types: 'uint8' */
     "rgba s3tc dxt5" |
+    /* `ext.COMPRESSED_RGB_ATC_WEBGL`; channels: 3; types: 'uint8' */
     "rgb atc" |
+    /* `ext.COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL`; channels: 4; types: 'uint8' */
     "rgba atc explicit alpha" |
+    /* `ext.COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL`; channels: 4; types: 'uint8' */
     "rgba atc interpolated alpha" |
+    /* `ext.COMPRESSED_RGB_PVRTC_4BPPV1_IMG`; channels: 3; types: 'uint8' */
     "rgb pvrtc 4bppv1" |
+    /* `ext.COMPRESSED_RGB_PVRTC_2BPPV1_IMG`; channels: 3; types: 'uint8' */
     "rgb pvrtc 2bppv1" |
+    /* `ext.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG`; channels: 4; types: 'uint8' */
     "rgba pvrtc 4bppv1" |
+    /* `ext.COMPRESSED_RGBA_PVRTC_2BPPV1_IMG`; channels: 4; types: 'uint8' */
     "rgba pvrtc 2bppv1" |
+    /* `ext.COMPRESSED_RGB_ETC1_WEBGL`; channels: 3; types: 'uint8' */
     "rgb etc1";
 
   type TextureDataType =
+    /* `gl.UNSIGNED_BYTE` */
     "uint8" |
+    /* `gl.UNSIGNED_SHORT` */
     "uint16" |
+    /* `gl.UNSIGNED_INT` */
     "uint32" |
-    "float" |
-    "half float";
+    /* `gl.FLOAT` */
+    "float" | "float32" |
+    /* `ext.HALF_FLOAT_OES` */
+    "half float" | "float16";
 
+  /* Related WebGL API: `gl.MAG_FILTER` */
   type TextureMagFilterType =
+    /* `gl.NEAREST` */
     "nearest" |
+    /* `gl.LINEAR` */
     "linear";
 
+  /* Related WebGL API: `gl.MIN_FILTER` */
   type TextureMinFilterType =
+    /* `gl.NEAREST` */
     "nearest" |
+    /* `gl.LINEAR` */
     "linear" |
+    /* `gl.LINEAR_MIPMAP_LINEAR` */
     "linear mipmap linear" | "mipmap" |
+    /* `gl.NEAREST_MIPMAP_LINEAR` */
     "nearest mipmap linear" |
+    /* `gl.LINEAR_MIPMAP_NEAREST` */
     "linear mipmap nearest" |
+    /* `gl.NEAREST_MIPMAP_NEAREST` */
     "nearest mipmap nearest";
 
   type TextureWrapModeType =
+    /* `gl.REPEAT` */
     "repeat" |
+    /* `gl.CLAMP_TO_EDGE` */
     "clamp" |
+    /* `gl.MIRRORED_REPEAT` */
     "mirror";
 
   interface Texture2D extends Texture {
@@ -1064,16 +1106,31 @@ declare namespace REGL {
   }
 
   type TextureMipmapHintType =
+    /* `gl.DONT_CARE` */
     "don't care" | "dont care" |
+    /* `gl.NICEST` */
     "nice" |
+    /* `gl.FASTEST` */
     "fast";
 
   type TextureColorSpaceType =
-    "none" | "browser";
+    /* `gl.NONE` */
+    "none" |
+    /* gl.BROWSER_DEFAULT_WEBGL` */
+    "browser";
 
   type TextureChannelsType = 1 | 2 | 3 | 4;
 
-  type TextureUnpackAlignmentType = 1 | 2 | 4 | 8;
+  /* Related WebGL API: `gl.pixelStorei` */
+  type TextureUnpackAlignmentType =
+    /* byte-alignment */
+    1 |
+    /* rows aligned to even-numbered bytes */
+    2 |
+    /* word-alignment */
+    4 |
+    /* rows start on double-word boundaries */
+    8;
 
   interface TextureCube extends Texture {
     resize(): void;

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -434,9 +434,9 @@ declare namespace REGL {
     /* Shaders */
 
     /** Source code of vertex shader */
-    vert?: string;
+    vert?: MaybeDynamic<string, ParentContext & OwnContext, Props>;
     /** Source code of fragment shader */
-    frag?: string;
+    frag?: MaybeDynamic<string, ParentContext & OwnContext, Props>;
 
     /**
      * Object mapping user-defined keys to user-defined values to be accessed via `DynamicVariable`s
@@ -481,21 +481,21 @@ declare namespace REGL {
     /**
      * Sets the primitive type. (Default: 'triangles', or inferred from `elements`)
      */
-    primitive?: REGL.PrimitiveType;
+    primitive?: MaybeDynamic<REGL.PrimitiveType, ParentContext & OwnContext, Props>;
     /**
      * Number of vertices to draw. (Default: 0, or inferred from `elements`)
      */
-    count?: number;
+    count?: MaybeDynamic<number, ParentContext & OwnContext, Props>;
     /**
      * Offset of primitives to draw. (Default: 0, or inferred from `elements`)
      */
-    offset?: number;
+    offset?: MaybeDynamic<number, ParentContext & OwnContext, Props>;
     /**
      * Number of instances to draw. (Default: 0)
      *
      * Only applicable if the `ANGLE_instanced_arrays` extension is present.
      */
-    instances?: number;
+    instances?: MaybeDynamic<number, ParentContext & OwnContext, Props>;
     /**
      * Element array buffer. (Default: `null`)
      *
@@ -503,7 +503,11 @@ declare namespace REGL {
      * If `elements` is specified while `primitive`, `count` and `offset` are not,
      * then these values may be inferred from the state of the element array buffer.
      */
-    elements?: REGL.Elements | ElementsData | ElementsOptions | null;
+    elements?: MaybeDynamic<
+      REGL.Elements | ElementsData | ElementsOptions | null,
+      ParentContext & OwnContext,
+      Props
+    >;
 
     /* Render target */
 
@@ -516,7 +520,7 @@ declare namespace REGL {
      *
      * - [gl.bindFramebuffer](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindFramebuffer.xml)
      */
-    framebuffer?: REGL.Framebuffer | null;
+    framebuffer?: MaybeDynamic<REGL.Framebuffer | null, ParentContext & OwnContext, Props>;
 
     /* Profiling */
 
@@ -524,7 +528,7 @@ declare namespace REGL {
      * If set, turns on profiling for this command. (Default: `false`)
      * Profiling stats can be accessed via the `stats` property of the `DrawCommand`.
      */
-    profile?: boolean;
+    profile?: MaybeDynamic<boolean, ParentContext & OwnContext, Props>;
 
     /* Depth buffer */
 
@@ -535,7 +539,7 @@ declare namespace REGL {
      * - gl.depthMask
      * - gl.depthRange
      */
-    depth?: REGL.DepthTestOptions;
+    depth?: MaybeDynamic<REGL.DepthTestOptions, ParentContext & OwnContext, Props>;
 
     /* Blending */
 
@@ -546,7 +550,7 @@ declare namespace REGL {
      * - gl.blendFuncSeparate
      * - gl.blendColor
      */
-    blend?: REGL.BlendingOptions;
+    blend?: MaybeDynamic<REGL.BlendingOptions, ParentContext & OwnContext, Props>;
 
     /* Stencil */
 
@@ -557,7 +561,7 @@ declare namespace REGL {
      * - gl.stencilMask
      * - gl.stencilOpSeparate
      */
-    stencil?: REGL.StencilOptions;
+    stencil?: MaybeDynamic<REGL.StencilOptions, ParentContext & OwnContext, Props>;
 
     /* Polygon offset */
 
@@ -566,39 +570,39 @@ declare namespace REGL {
      *
      * - gl.polygonOffset
      */
-    polygonOffset?: REGL.PolygonOffsetOptions;
+    polygonOffset?: MaybeDynamic<REGL.PolygonOffsetOptions, ParentContext & OwnContext, Props>;
 
     /* Culling */
 
-    cull?: REGL.CullingOptions;
+    cull?: MaybeDynamic<REGL.CullingOptions, ParentContext & OwnContext, Props>;
 
     /* Front face */
 
     /* Sets gl.frontFace. Default: 'ccw' */
-    frontFace?: REGL.FaceWindingType;
+    frontFace?: MaybeDynamic<REGL.FaceWindingType, ParentContext & OwnContext, Props>;
 
     /* Dithering */
 
     /* Toggles `gl.DITHER`. Default: false */
-    dither?: boolean;
+    dither?: MaybeDynamic<boolean, ParentContext & OwnContext, Props>;
 
     /* Line width */
 
     /* Sets `gl.lineWidth`. Default: 1 */
-    lineWidth?: number;
+    lineWidth?: MaybeDynamic<number, ParentContext & OwnContext, Props>;
 
     /* Color mask */
 
     /* Sets `gl.colorMask`. Default: [true, true, true, true] */
-    colorMask?: [boolean, boolean, boolean, boolean];
+    colorMask?: MaybeDynamic<[boolean, boolean, boolean, boolean], ParentContext & OwnContext, Props>;
 
     /* Sample coverage */
 
-    sample?: REGL.SamplingOptions;
+    sample?: MaybeDynamic<REGL.SamplingOptions, ParentContext & OwnContext, Props>;
 
     /* Scissor */
 
-    scissor?: REGL.ScissorOptions;
+    scissor?: MaybeDynamic<REGL.ScissorOptions, ParentContext & OwnContext, Props>;
 
     /* Viewport */
 
@@ -606,7 +610,7 @@ declare namespace REGL {
      * Sets `gl.viewport`. Default: {}
      * Updating `viewport` will modify the context variables `viewportWidth` and `viewportHeight`.
      */
-    viewport?: REGL.BoundingBox;
+    viewport?: MaybeDynamic<REGL.BoundingBox, ParentContext & OwnContext, Props>;
   }
 
   type PrimitiveType =

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -145,8 +145,20 @@ declare namespace REGL {
 
     renderbuffer(options: REGL.RenderbufferOptions): REGL.Renderbuffer;
 
+    /* Creates a Framebuffer of dimensions 1 x 1. */
+    framebuffer(): REGL.Framebuffer;
+    /* Creates a Framebuffer of dimensions `radius` x `radius`. */
+    framebuffer(radius: number): REGL.Framebuffer;
+    /* Creates a Framebuffer of dimensions `width` x `height`. */
+    framebuffer(width: number, height: number): REGL.Framebuffer;
+    /* Creates a Framebuffer using creation `options`. */
     framebuffer(options: REGL.FramebufferOptions): REGL.Framebuffer;
 
+    /* Creates a FramebufferCube whose faces have dimensions 1 x 1. */
+    framebufferCube(): REGL.FramebufferCube;
+    /* Creates a FramebufferCube whose faces have dimensions `radius` x `radius`. */
+    framebufferCube(radius: number): REGL.FramebufferCube;
+    /* Creates a FramebufferCube using creation `options`. */
     framebufferCube(options: REGL.FramebufferCubeOptions): REGL.FramebufferCube;
 
     /* Events and listeners */
@@ -912,7 +924,13 @@ declare namespace REGL {
   }
 
   interface Framebuffer extends Resource {
-    // TODO check if FBO has `stats: { size: number; }` and other properties.
+    /* Reinitializes the Framebuffer in place using dimensions: 1 x 1. */
+    (): void;
+    /* Reinitializes the Framebuffer in place using dimensions: `radius` x `radius`. */
+    (radius: number): void;
+    /* Reinitializes the Framebuffer in place using dimensions: `width` x `height`. */
+    (width: number, height: number): void;
+    /* Reinitializes the Framebuffer in place using creation `options`. */
     (options: FramebufferOptions): void;
 
     /* Framebuffer binding */
@@ -948,6 +966,11 @@ declare namespace REGL {
   }
 
   interface FramebufferCube extends Resource {
+    /* Reinitializes the FramebufferCube in place using face dimensions 1 x 1. */
+    (): void;
+    /* Reinitializes the FramebufferCube in place using face dimensions `radius` x `radius`. */
+    (radius: number): void;
+    /* Reinitializes the FramebufferCube in place using creation `options`. */
     (options: FramebufferCubeOptions): void;
 
     // resize(): void;

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -191,6 +191,13 @@ declare namespace REGL {
     /* Creates a cube-map texture using creation `options`. */
     cube(options: REGL.TextureCubeOptions): REGL.TextureCube;
 
+    /* Creates a Renderbuffer of dimensions 1 x 1. */
+    renderbuffer(): REGL.Renderbuffer;
+    /* Creates a Renderbuffer of dimensions `radius` x `radius`. */
+    renderbuffer(radius: number): REGL.Renderbuffer;
+    /* Creates a Renderbuffer of dimensions `width` x `height`. */
+    renderbuffer(width: number, height: number): REGL.Renderbuffer;
+    /* Creates a Renderbuffer using creation `options`. */
     renderbuffer(options: REGL.RenderbufferOptions): REGL.Renderbuffer;
 
     /* Creates a Framebuffer of dimensions 1 x 1. */
@@ -1366,30 +1373,41 @@ declare namespace REGL {
     /** Format of the renderbuffer. */
     readonly format: number;
 
-    (options: REGL.RenderbufferOptions): void;
+    /* Reinitializes the Renderbuffer in place using dimensions: 1 x 1. */
+    (): void;
+    /* Reinitializes the Renderbuffer in place using dimensions: `radius` x `radius`. */
+    (radius: number): void;
+    /* Reinitializes the Renderbuffer in place using dimensions: `width` x `height`. */
+    (width: number, height: number): void;
+    /* Reinitializes the Renderbuffer in place using creation `options`. */
+    (options: RenderbufferOptions): void;
 
-    // resize(): void; // TODO Check implementation if this signature is valid
-    // resize(radius: number): void; // TODO Check implementation if this signature is valid
+    /* Resizes the Renderbuffer. */
+    resize(radius: number): void;
     resize(width: number, height: number): void;
   }
 
   interface RenderbufferOptions {
-    /** Sets the internal format of the render buffer (Default `'rgba4'`) */
-    format?: REGL.RenderbufferFormat;
-    /** Sets the width of the render buffer in pixels. (Default `1`) */
-    width?: number;
-    /** Sets the height of the render buffer in pixels. (Default `1`) */
-    height?: number;
-    /** Alias for `[width, height]`. (Default `[1, 1]`) */
+    /* NB: `shape`, `radius`, and `width`/`height` are alternative (and mutually exclusive) means for setting the size of the renderbuffer. */
+    /* Sets the dimensions [width, height] for the renderbuffer. */
     shape?: [number, number];
-    /** Simultaneously sets width and height. (Default `1`) */
+    /* Sets the dimensions `radius` x `radius` for the renderbuffer. */
     radius?: number;
+    /* Sets the width of the renderbuffer. Default: `gl.drawingBufferWidth` */
+    width?: number;
+    /* Sets the height of the renderbuffer. Default: `gl.drawingBufferHeight` */
+    height?: number;
+    /** Sets the internal format of the render buffer. Default 'rgba4' */
+    format?: REGL.RenderbufferFormat;
   }
 
   type RenderbufferFormat =
     RenderbufferColorFormat |
+    /* `gl.DEPTH_COMPONENT16` */
     "depth" |
+    /* `gl.STENCIL_INDEX8` */
     "stencil" |
+    /* `gl.DEPTH_STENCIL` */
     "depth stencil";
 
   type RenderbufferColorFormat =

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -603,7 +603,7 @@ declare namespace REGL {
     /**
      * - [gl.viewport](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glViewport.xml)
      */
-    viewport?: REGL.ViewportOptions;
+    viewport?: REGL.BoundingBox;
   }
 
   type PrimitiveType =
@@ -846,11 +846,15 @@ declare namespace REGL {
     "decrement wrap";
 
   interface PolygonOffsetOptions {
+    /* Toggles `gl.enable(gl.POLYGON_OFFSET_FILL)`. Default: false */
     enable?: boolean;
-    offset: {
-      factor: number;
-      units: number;
-    }
+    /* Sets `gl.polygonOffset`. Default: { factor: 0, units: 0 } */
+    offset?: REGL.PolygonOffset;
+  }
+
+  interface PolygonOffset {
+    factor: number;
+    units: number;
   }
 
   interface CullingOptions {
@@ -871,28 +875,31 @@ declare namespace REGL {
     enable?: boolean;
     /** Toggles `gl.enable(gl.SAMPLE_ALPHA_TO_COVERAGE)` */
     alpha?: boolean;
-    /** Sets `gl.sampleCoverage` */
-    coverage?: {
-      value: number;
-      invert: boolean;
-    }
+    /** Sets `gl.sampleCoverage`. Default: { value: 1, invert: false } */
+    coverage?: REGL.SampleCoverage;
+  }
+
+  interface SampleCoverage {
+    value: number;
+    invert: boolean;
   }
 
   interface ScissorOptions {
-    enable: boolean;
-    box: {
-      x: number;
-      y: number;
-      width: number;
-      height: number;
-    }
+    /* Toggles gl.enable(gl.SCISSOR). Default: false */
+    enable?: boolean;
+    /* Sets `gl.SCISSOR`. Default: {} */
+    box?: REGL.BoundingBox;
   }
 
-  interface ViewportOptions {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
+  interface BoundingBox {
+    /* left coordinate of the box; Default: 0 */
+    x?: number;
+    /* top coordiante of the box; Default: 0 */
+    y?: number;
+    /* width of the box; Default: framebuffer width - `x` */
+    width?: number;
+    /* height of the box; Default: framebuffer height - `y` */
+    height?: number;
   }
 
   /*

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -935,13 +935,10 @@ declare namespace REGL {
 
     /* Framebuffer binding */
 
-    /**
-     * For convenience it is possible to bind a framebuffer directly.
-     * This is a short cut for creating a command which sets the framebuffer.
-     */
+    /* Binds a framebuffer directly. This is a short cut for creating a command which sets the framebuffer. */
     use(body: CommandBodyFn): void;
 
-    // resize(): void;
+    /* Resizes the Framebuffer and all its attachments. */
     resize(radius: number): void;
     resize(width: number, height: number): void;
   }
@@ -973,7 +970,7 @@ declare namespace REGL {
     /* Reinitializes the FramebufferCube in place using creation `options`. */
     (options: FramebufferCubeOptions): void;
 
-    // resize(): void;
+    /* Resizes the FramebufferCube and all its attachments. */
     resize(radius: number): void;
   }
 

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -172,12 +172,23 @@ declare namespace REGL {
     /* Creates a 2D Texture using creation `options`. */
     texture(options: REGL.Texture2DOptions): REGL.Texture2D;
 
-    cube(radius?: number): REGL.TextureCube;
+    /* Creates a cube-map texture with faces of dimensions 1 x 1. */
+    cube(): REGL.TextureCube;
+    /* Creates a cube-map texture with faces of dimensions `radius` x `radius`. */
+    cube(radius: number): REGL.TextureCube;
+    /* Creates a cube-map texture using the provided image data for the six faces. */
     cube(
-      posX: REGL.TextureImageData, negX: REGL.TextureImageData,
-      posY: REGL.TextureImageData, negY: REGL.TextureImageData,
-      posZ: REGL.TextureImageData, negZ: REGL.TextureImageData
+      posXData: REGL.TextureImageData, negXData: REGL.TextureImageData,
+      posYData: REGL.TextureImageData, negYData: REGL.TextureImageData,
+      posZData: REGL.TextureImageData, negZData: REGL.TextureImageData
     ): REGL.TextureCube;
+    /* Creates a cube-map texture using the provided creation options for the six faces. */
+    cube(
+      posXOptions: REGL.Texture2DOptions, negXOptions: REGL.Texture2DOptions,
+      posYOptions: REGL.Texture2DOptions, negYOptions: REGL.Texture2DOptions,
+      posZOptions: REGL.Texture2DOptions, negZOptions: REGL.Texture2DOptions,
+    ): REGL.TextureCube;
+    /* Creates a cube-map texture using creation `options`. */
     cube(options: REGL.TextureCubeOptions): REGL.TextureCube;
 
     renderbuffer(options: REGL.RenderbufferOptions): REGL.Renderbuffer;
@@ -1203,23 +1214,63 @@ declare namespace REGL {
     8;
 
   interface TextureCube extends Texture {
-    resize(): void;
-    resize(radius: number): void;
+    /* Reinitializes the texture in place with faces of dimensions 1 x 1. */
+    (): void;
+    /* Reinitializes the texture in place with faces of dimensions `radius` x `radius`. */
+    (radius: number): void;
+    /* Reinitializes the texture in place using the provided image data for the six faces. */
+    (
+      posXData: REGL.TextureImageData, negXData: REGL.TextureImageData,
+      posYData: REGL.TextureImageData, negYData: REGL.TextureImageData,
+      posZData: REGL.TextureImageData, negZData: REGL.TextureImageData
+    ): void;
+    /* Reinitializes the texture in place using the provided creation options for the six faces. */
+    (
+      posXOptions: REGL.Texture2DOptions, negXOptions: REGL.Texture2DOptions,
+      posYOptions: REGL.Texture2DOptions, negYOptions: REGL.Texture2DOptions,
+      posZOptions: REGL.Texture2DOptions, negZOptions: REGL.Texture2DOptions,
+    ): void;
+    /* Reinitializes the texture in place using creation `options`. */
+    (options: REGL.TextureCubeOptions): void;
 
+    /**
+     * Replaces the part of texture with new data.
+     *
+     * @param face      index of the face to modify
+     * @param data      2D image data object to use for the replacement
+     * @param x         horizontal offset of the image within the face (Default: `0`)
+     * @param y         vertical offset of the image within the face (Default: `0`)
+     * @param level     mipmap level of the texture to modify (Default: `0`)
+     */
     subimage(
-      face: REGL.TextureCubeFaceIndexType,
+      face: REGL.TextureCubeFaceIndex,
       data: TextureImageData,
       x?: number,
       y?: number,
       level?: number,
     ): void;
+
+    /** Resizes the cube-map texture, setting the dimensions of each face to `radius` x `radius`. */
+    resize(radius: number): void;
   }
 
-  type TextureCubeFaceIndexType = 0 | 1 | 2 | 3 | 4 | 5;
+  type TextureCubeFaceIndex =
+    /* positive X face */
+    0 |
+    /* negative X face */
+    1 |
+    /* positive Y face */
+    2 |
+    /* negative Y face */
+    3 |
+    /* positive Z face */
+    4 |
+    /* negative Z face */
+    5;
 
-  interface TextureCubeOptions {
-    radius?: number;
-    faces?: [
+  interface TextureCubeOptions extends Texture2DOptions {
+    /* Uses the provided texture data for the six faces. */
+    faces: [
       TextureImageData, TextureImageData,
       TextureImageData, TextureImageData,
       TextureImageData, TextureImageData

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -789,34 +789,60 @@ declare namespace REGL {
     "src alpha saturate";
 
   interface StencilOptions {
+    /* Toggles `gl.enable(gl.STENCIL_TEST)`. Default: false */
     enable?: boolean;
+    /* Sets `gl.stencilMask`. Default: -1 */
     mask?: number;
+    /* Sets `gl.stencilFunc`. Default: { cmp: 'always', ref: 0, mask: -1 } */
     func?: REGL.StencilFunction;
+    /**
+     * Sets `gl.stencilOpSeparate` for front face.
+     * Default: { fail: 'keep', zfail: 'keep', zpass: 'keep' }
+     */
     opFront?: REGL.StencilOperation;
+    /**
+     * Sets `gl.stencilOpSeparate` for back face.
+     * Default: { fail: 'keep', zfail: 'keep', zpass: 'keep' }
+     */
     opBack?: REGL.StencilOperation;
+    /* Sets opFront and opBack simultaneously (`gl.stencilOp`). */
     op?: REGL.StencilOperation;
   }
 
   interface StencilFunction {
+    /* comparison function */
     cmp: REGL.ComparisonOperatorType;
+    /* reference value */
     ref: number;
+    /* comparison mask */
     mask: number;
   }
 
   interface StencilOperation {
+    /* The stencil operation applied when the stencil test fails. */
     fail: REGL.StencilOperationType;
+    /* The stencil operation applied when the stencil test passes and the depth test fails. */
     zfail: REGL.StencilOperationType;
+    /* The stencil operation applied when when both stencil and depth tests pass. */
     zpass: REGL.StencilOperationType;
   }
 
   type StencilOperationType =
+    /* `gl.ZERO` */
     "zero" |
+    /* `gl.KEEP` */
     "keep" |
+    /* `gl.REPLACE` */
     "replace" |
+    /* `gl.INVERT` */
     "invert" |
+    /* `gl.INCR` */
     "increment" |
+    /* `gl.DECR` */
     "decrement" |
+    /* `gl.INCR_WRAP` */
     "increment wrap" |
+    /* `gl.DECR_WRAP` */
     "decrement wrap";
 
   interface PolygonOffsetOptions {

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -307,9 +307,9 @@ declare namespace REGL {
     framebuffer?: REGL.Framebuffer | null;
   }
 
-  interface ReadOptions<T> {
-    /** An optional ArrayBufferView which gets the result of reading the pixels. (Default: `null`) */
-    data?: T;
+  interface ReadOptions<T = Uint8Array> {
+    /** An optional TypedArray which gets the result of reading the pixels. (Default: `null`, i.e. return a new TypedArray) */
+    data?: T | null;
     /** The x-offset of the upper-left corner of the rectangle in pixels. (Default: `0`) */
     x?: number;
     /** The y-offset of the upper-left corner of the rectangle in pixels. (Default: `0`) */

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -844,6 +844,8 @@ declare namespace REGL {
     vendor?: string;
     /** gl.VERSION */
     version?: string;
+    /** A list of all supported texture formats */
+    textureFormats: TextureFormatType[];
   }
 
   // TODO Revise the types of `REGL.Stats`

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -948,15 +948,15 @@ declare namespace REGL {
      * Reinitializes the buffer with the new content.
      * Relevant WebGL API: `gl.bufferData`
      */
-    (data: REGL.BufferData): void;
-    (options: REGL.BufferOptions): void;
+    (data: REGL.BufferData): REGL.Buffer;
+    (options: REGL.BufferOptions): REGL.Buffer;
 
     /**
      * Update a portion of the buffer, optionally starting at byte offset `offset`.
      * Relevant WebGL API: `gl.bufferSubData`
      */
-    subdata(data: REGL.BufferData, offset?: number): void;
-    subdata(options: REGL.BufferOptions, offset?: number): void;
+    subdata(data: REGL.BufferData, offset?: number): REGL.Buffer;
+    subdata(options: REGL.BufferOptions, offset?: number): REGL.Buffer;
   }
 
   interface BufferOptions {
@@ -1014,15 +1014,15 @@ declare namespace REGL {
      * Reinitializes the element buffer with the new content.
      * Relevant WebGL API: `gl.bufferData`
      */
-    (data: ElementsData): void;
-    (options: ElementsOptions): void;
+    (data: REGL.ElementsData): REGL.Elements;
+    (options: REGL.ElementsOptions): REGL.Elements;
 
     /**
      * Update a portion of the element buffer, optionally starting at byte offset `offset`.
      * Relevant WebGL API: `gl.bufferSubData`
      */
-    subdata(data: ElementsData, offset?: number): void;
-    subdata(options: ElementsOptions, offset?: number): void;
+    subdata(data: REGL.ElementsData, offset?: number): REGL.Elements;
+    subdata(options: REGL.ElementsOptions, offset?: number): REGL.Elements;
   }
 
   interface ElementsOptions {
@@ -1170,15 +1170,15 @@ declare namespace REGL {
 
   interface Texture2D extends Texture {
     /* Reinitializes the texture in place with dimensions 1 x 1. */
-    (): void;
+    (): REGL.Texture2D;
     /* Reinitializes the texture in place with dimensions `radius` x `radius`. */
-    (radius: number): void;
+    (radius: number): REGL.Texture2D;
     /* Reinitializes the texture in place with dimensions `width` x `height`. */
-    (width: number, height: number): void;
+    (width: number, height: number): REGL.Texture2D;
     /* Reinitializes the texture in place using the provided `data`. */
-    (data: REGL.TextureImageData): void;
+    (data: REGL.TextureImageData): REGL.Texture2D;
     /* Reinitializes the texture in place using creation `options`. */
-    (options: REGL.Texture2DOptions): void;
+    (options: REGL.Texture2DOptions): REGL.Texture2D;
 
     /**
      * Replaces the part of texture with new data.
@@ -1189,14 +1189,14 @@ declare namespace REGL {
      * @param level     mipmap level of the texture to modify (Default: `0`)
      */
     /* Replaces the area at offset `x` (default: 0), `y` (default: 0), with `data`. */
-    subimage(data: REGL.TextureImageData, x?: number, y?: number, level?: number): void;
+    subimage(data: REGL.TextureImageData, x?: number, y?: number, level?: number): REGL.Texture2D;
     /* Replaces a subset of the image using creation `options`. */
-    subimage(options: Texture2DOptions): void;
+    subimage(options: Texture2DOptions): REGL.Texture2D;
 
     /** Resizes the texture to `radius` x `radius`. */
-    resize(radius: number): void;
+    resize(radius: number): REGL.Texture2D;
     /** Resizes the texture to dimensions `width` x `height`. */
-    resize(width: number, height: number): void;
+    resize(width: number, height: number): REGL.Texture2D;
   }
 
   interface Texture2DOptions {
@@ -1315,23 +1315,23 @@ declare namespace REGL {
 
   interface TextureCube extends Texture {
     /* Reinitializes the texture in place with faces of dimensions 1 x 1. */
-    (): void;
+    (): REGL.TextureCube;
     /* Reinitializes the texture in place with faces of dimensions `radius` x `radius`. */
-    (radius: number): void;
+    (radius: number): REGL.TextureCube;
     /* Reinitializes the texture in place using the provided image data for the six faces. */
     (
       posXData: REGL.TextureImageData, negXData: REGL.TextureImageData,
       posYData: REGL.TextureImageData, negYData: REGL.TextureImageData,
       posZData: REGL.TextureImageData, negZData: REGL.TextureImageData
-    ): void;
+    ): REGL.TextureCube;
     /* Reinitializes the texture in place using the provided creation options for the six faces. */
     (
       posXOptions: REGL.Texture2DOptions, negXOptions: REGL.Texture2DOptions,
       posYOptions: REGL.Texture2DOptions, negYOptions: REGL.Texture2DOptions,
       posZOptions: REGL.Texture2DOptions, negZOptions: REGL.Texture2DOptions,
-    ): void;
+    ): REGL.TextureCube;
     /* Reinitializes the texture in place using creation `options`. */
-    (options: REGL.TextureCubeOptions): void;
+    (options: REGL.TextureCubeOptions): REGL.TextureCube;
 
     /**
      * Replaces the part of texture with new data.
@@ -1348,10 +1348,10 @@ declare namespace REGL {
       x?: number,
       y?: number,
       level?: number,
-    ): void;
+    ): REGL.TextureCube;
 
     /** Resizes the cube-map texture, setting the dimensions of each face to `radius` x `radius`. */
-    resize(radius: number): void;
+    resize(radius: number): REGL.TextureCube;
   }
 
   type TextureCubeFaceIndex =
@@ -1391,17 +1391,17 @@ declare namespace REGL {
     readonly format: number;
 
     /* Reinitializes the Renderbuffer in place using dimensions: 1 x 1. */
-    (): void;
+    (): REGL.Renderbuffer;
     /* Reinitializes the Renderbuffer in place using dimensions: `radius` x `radius`. */
-    (radius: number): void;
+    (radius: number): REGL.Renderbuffer;
     /* Reinitializes the Renderbuffer in place using dimensions: `width` x `height`. */
-    (width: number, height: number): void;
+    (width: number, height: number): REGL.Renderbuffer;
     /* Reinitializes the Renderbuffer in place using creation `options`. */
-    (options: RenderbufferOptions): void;
+    (options: REGL.RenderbufferOptions): REGL.Renderbuffer;
 
     /* Resizes the Renderbuffer. */
-    resize(radius: number): void;
-    resize(width: number, height: number): void;
+    resize(radius: number): REGL.Renderbuffer;
+    resize(width: number, height: number): REGL.Renderbuffer;
   }
 
   interface RenderbufferOptions {
@@ -1447,13 +1447,13 @@ declare namespace REGL {
 
   interface Framebuffer2D extends Resource {
     /* Reinitializes the Framebuffer in place using dimensions: 1 x 1. */
-    (): void;
+    (): REGL.Framebuffer2D;
     /* Reinitializes the Framebuffer in place using dimensions: `radius` x `radius`. */
-    (radius: number): void;
+    (radius: number): REGL.Framebuffer2D;
     /* Reinitializes the Framebuffer in place using dimensions: `width` x `height`. */
-    (width: number, height: number): void;
+    (width: number, height: number): REGL.Framebuffer2D;
     /* Reinitializes the Framebuffer in place using creation `options`. */
-    (options: FramebufferOptions): void;
+    (options: REGL.FramebufferOptions): REGL.Framebuffer2D;
 
     /* Framebuffer binding */
 
@@ -1464,8 +1464,8 @@ declare namespace REGL {
     >(body: CommandBodyFn<Context, Props>): void;
 
     /* Resizes the Framebuffer and all its attachments. */
-    resize(radius: number): void;
-    resize(width: number, height: number): void;
+    resize(radius: number): REGL.Framebuffer2D;
+    resize(width: number, height: number): REGL.Framebuffer2D;
   }
 
   interface FramebufferOptions {
@@ -1504,14 +1504,14 @@ declare namespace REGL {
 
   interface FramebufferCube extends Resource {
     /* Reinitializes the FramebufferCube in place using face dimensions 1 x 1. */
-    (): void;
+    (): REGL.FramebufferCube;
     /* Reinitializes the FramebufferCube in place using face dimensions `radius` x `radius`. */
-    (radius: number): void;
+    (radius: number): REGL.FramebufferCube;
     /* Reinitializes the FramebufferCube in place using creation `options`. */
-    (options: FramebufferCubeOptions): void;
+    (options: FramebufferCubeOptions): REGL.FramebufferCube;
 
     /* Resizes the FramebufferCube and all its attachments. */
-    resize(radius: number): void;
+    resize(radius: number): REGL.FramebufferCube;
   }
 
   interface FramebufferCubeOptions {

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -183,14 +183,13 @@ declare namespace REGL {
      * so you should try to do all your rendering to the drawing buffer within
      * the frame callback.
      */
-    frame(callback: () => void): REGL.Cancel;
+    frame(callback: REGL.FrameCallback): REGL.Cancellable;
 
-    on(type: "frame", handler: () => void): REGL.Cancel;
-    on(type: "lost", handler: () => void): REGL.Cancel;
-    on(type: "restore", handler: () => void): REGL.Cancel;
-    on(type: "destroy", handler: () => void): REGL.Cancel;
-
-    /* Extensions */
+    /**
+     * Registers a handler function to be called when the associated `regl` event is fired.
+     */
+    on(type: 'frame', callback: REGL.FrameCallback): REGL.Cancellable
+    on(type: 'lost' | 'restore' | 'destroy', callback: () => void): REGL.Cancellable;
 
     /**
      * Test if an extension is present. Argument is case insensitive.
@@ -271,7 +270,7 @@ declare namespace REGL {
     readonly pixelRatio: number;
   }
 
-  interface Cancel {
+  interface Cancellable {
     cancel(): void;
   }
 

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -87,18 +87,21 @@ declare namespace REGL {
 
     /**
      * Read entire screen.
+     * NB: Reading into a Float32Array requires OES_texture_float.
      */
-    read(): Uint8Array | Float32Array;
+    read<T extends Uint8Array | Float32Array = Uint8Array>(): T;
 
     /**
-     * Read entire screen into an existing `ArrayBufferView`.
+     * Read entire screen into an existing TypedArray.
+     * NB: Reading into a Float32Array requires OES_texture_float.
      */
     read<T extends Uint8Array | Float32Array>(data: T): T;
 
     /**
      * Read a selected region of screen or framebuffer.
+     * NB: Reading into a Float32Array requires OES_texture_float.
      */
-    read<T extends Uint8Array | Float32Array>(options: REGL.ReadOptions<T>): T;
+    read<T extends Uint8Array | Float32Array = Uint8Array>(options: REGL.ReadOptions<T>): T;
 
     /**
      * Dynamic variable binding

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -722,7 +722,7 @@ declare namespace REGL {
     wrapS?: REGL.TextureWrapModeType;
     wrapT?: REGL.TextureWrapModeType;
     aniso?: number;
-    type?: REGL.TextureDataTypeType;
+    type?: REGL.TextureDataType;
 
     mipmap?: REGL.TextureMipmapHintType;
     flipY?: boolean;
@@ -746,7 +746,7 @@ declare namespace REGL {
     /** Texture format. */
     readonly format: REGL.TextureFormatType;
     /** Texture data type. */
-    readonly type: REGL.TextureDataTypeType;
+    readonly type: REGL.TextureDataType;
     /** Texture magnification filter. */
     readonly mag: REGL.TextureMagFilterType;
     /** Texture minification filter. */
@@ -840,7 +840,7 @@ declare namespace REGL {
     // Sets the format of the color buffer. Ignored if color	'rgba'
     colorFormat?: REGL.FramebufferColorFormatType;
     // Sets the type of the color buffer if it is a texture	'uint8'
-    colorType?: REGL.FramebufferColorDataTypeType;
+    colorType?: REGL.FramebufferColorDataType;
     // Sets the number of color buffers. Values > 1 require WEBGL_draw_buffers	1
     colorCount?: number;
     // Toggles whether depth/stencil attachments should be in texture. Requires WEBGL_depth_texture	false
@@ -872,7 +872,7 @@ declare namespace REGL {
     /** Format of color buffer to create. */
     colorFormat?: "rgba"; // TODO Color formats for `FramebufferCube` other that `rgba`?
     /** Type of color buffer. */
-    colorType?: FramebufferColorDataTypeType;
+    colorType?: FramebufferColorDataType;
     /** Number of color attachments. */
     colorCount?: number;
     /** Depth buffer attachment. */
@@ -1089,7 +1089,7 @@ declare namespace REGL {
     "rgba pvrtc 2bppv1" |
     "rgb etc1";
 
-  type TextureDataTypeType =
+  type TextureDataType =
     "uint8" |
     "uint16" |
     "uint32" |
@@ -1149,7 +1149,7 @@ declare namespace REGL {
     "rgba32f" |
     "srgba";
 
-  type FramebufferColorDataTypeType =
+  type FramebufferColorDataType =
     "uint8" |
     "half float" |
     "float";

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -709,42 +709,83 @@ declare namespace REGL {
     "notequal" | "!=";
 
   interface BlendingOptions {
+    /* Toggles `gl.enable(gl.BLEND)`. Default: false */
     enable?: boolean;
-    func?: {
-      srcRGB: BlendingFunctionType;
-      srcAlpha: BlendingFunctionType;
-      dstRGB: BlendingFunctionType;
-      dstAlpha: BlendingFunctionType;
-    };
-    equation?: {
-      rgb?: REGL.BlendingEquationType;
-      alpha?: string;
-    };
+    /**
+     * `equation` can be either a string or an object with the fields {rgb, alpha}.
+     * The former corresponds to `gl.blendEquation` and the latter to `gl.blendEquationSeparate`.
+     * Default: 'add'
+     */
+    equation?: REGL.BlendingEquation | REGL.BlendingEquationSeparate;
+    /**
+     * `func` can be an object with the fields {src, dst} or {srcRGB, srcAlpha, dstRGB, dstAlpha},
+     * with the former corresponding to gl.blendFunc and the latter to gl.blendFuncSeparate.
+     * Default: { src: 'src alpha', dst: 'one minus src alpha' }
+     */
+    func?: REGL.BlendingFunctionCombined | REGL.BlendingFunctionSeparate;
+    /* Sets `gl.blendColor` */
     color?: [number, number, number, number];
   }
 
-  type BlendingEquationType =
+  interface BlendingEquationSeparate {
+    rgb: REGL.BlendingEquation;
+    alpha: REGL.BlendingEquation;
+  }
+
+  type BlendingEquation =
+    /* `gl.FUNC_ADD` */
     "add" |
+    /* `gl.FUNC_SUBTRACT` */
     "subtract" |
+    /* `gl.FUNC_REVERSE_SUBTRACT` */
     "reverse subtract" |
+    /* `gl.MIN_EXT`, requires `EXT_blend_minmax` */
     "min" |
+    /* `gl.MAX_EXT`, requires `EXT_blend_minmax` */
     "max";
 
-  type BlendingFunctionType =
+  interface BlendingFunctionCombined {
+    src: REGL.BlendingFunction;
+    dst: REGL.BlendingFunction;
+  }
+
+  interface BlendingFunctionSeparate {
+    srcRGB: REGL.BlendingFunction;
+    srcAlpha: REGL.BlendingFunction;
+    dstRGB: REGL.BlendingFunction;
+    dstAlpha: REGL.BlendingFunction;
+  }
+
+  type BlendingFunction =
+    /* `gl.ZERO` */
     "zero" | 0 |
+    /* `gl.ONE` */
     "one" | 1 |
+    /* `gl.SRC_COLOR` */
     "src color" |
+    /* `gl.ONE_MINUS_SRC_COLOR` */
     "one minus src color" |
+    /* `gl.SRC_ALPHA` */
     "src alpha" |
+    /* `gl.ONE_MINUS_SRC_ALPHA` */
     "one minus src alpha" |
+    /* `gl.DST_COLOR` */
     "dst color" |
+    /* `gl.ONE_MINUS_DST_COLOR` */
     "one minus dst color" |
+    /* `gl.DST_ALPHA` */
     "dst alpha" |
+    /* `gl.ONE_MINUS_DST_ALPHA` */
     "one minus dst alpha" |
+    /* `gl.CONSTANT_COLOR` */
     "constant color" |
+    /* `gl.ONE_MINUS_CONSTANT_COLOR` */
     "one minus constant color" |
+    /* `gl.CONSTANT_ALPHA` */
     "constant alpha" |
+    /* `gl.ONE_MINUS_CONSTANT_ALPHA` */
     "one minus constant alpha" |
+    /* `gl.SRC_ALPHA_SATURATE` */
     "src alpha saturate";
 
   interface StencilOptions {

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -74,7 +74,7 @@ declare namespace REGL {
      * Creates a new REGL command. The resulting command, when executed,
      * will set a WebGL state machine to a specified `state`.
      */
-    (state: REGL.State): REGL.Command;
+    (state: REGL.DrawConfig): REGL.DrawCommand;
 
     /**
      * Clears selected buffers to specified values.
@@ -335,7 +335,7 @@ declare namespace REGL {
    * A *command* is a complete representation of the WebGL state required
    * to perform some draw call.
    */
-  interface Command {
+  interface DrawCommand {
     readonly stats: REGL.CommandStats;
 
     /** Run a command once. */
@@ -346,7 +346,7 @@ declare namespace REGL {
     (props: REGL.Props | REGL.Props[], body?: REGL.CommandBodyFn): void;
   }
 
-  interface State {
+  interface DrawConfig {
 
     /* Shaders */
 

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -869,7 +869,7 @@ declare namespace REGL {
 
   interface RenderbufferOptions {
     /** Sets the internal format of the render buffer (Default `'rgba4'`) */
-    format?: REGL.RenderbufferFormatType;
+    format?: REGL.RenderbufferFormat;
     /** Sets the width of the render buffer in pixels. (Default `1`) */
     width?: number;
     /** Sets the height of the render buffer in pixels. (Default `1`) */
@@ -900,26 +900,37 @@ declare namespace REGL {
     resize(width: number, height: number): void;
   }
 
+  type Framebuffer2DAttachment = REGL.Texture2D | REGL.Renderbuffer;
+
   interface FramebufferOptions {
-    // Sets the width of the framebuffer	gl.drawingBufferWidth
+    /* NB: `shape`, `radius`, and `width`/`height` are alternative (and mutually exclusive) means for setting the size of the framebuffer. */
+    /* Sets the dimensions [width, height] for the framebuffer. */
+    shape?: [number, number];
+    /* Sets the dimensions `radius` x `radius` for the framebuffer. */
+    radius?: number;
+    /* Sets the width of the framebuffer. Default: `gl.drawingBufferWidth` */
     width?: number;
-    // Sets the height of the framebuffer	gl.drawingBufferHeight
+    /* Sets the height of the framebuffer. Default: `gl.drawingBufferHeight` */
     height?: number;
-    // An optional array of either textures renderbuffers for the color attachment.
-    color?: any; // TODO What is the valid type of `FramebufferOptions.color`?
-    // If boolean, then toggles the depth attachment. Otherwise if a renderbuffer/texture sets the depth attachment.	true
-    depth?: boolean | REGL.Renderbuffer | REGL.Texture; // TODO Is it `REGL.Texture2D` only?
-    // If boolean, then toggles the stencil attachment. Otherwise if a renderbuffer sets the stencil attachment.	true
-    stencil?: boolean | REGL.Renderbuffer; // TODO Does it support `REGL.Texture`?
-    // If boolean, then toggles both the depth and stencil attachment. Otherwise if a renderbuffer/texture sets the combined depth/stencil attachment.	true
-    depthStencil?: boolean | REGL.Renderbuffer | REGL.Texture; // TODO Is it `REGL.Texture2D` only?
-    // Sets the format of the color buffer. Ignored if color	'rgba'
-    colorFormat?: REGL.FramebufferColorFormatType;
-    // Sets the type of the color buffer if it is a texture	'uint8'
+
+    /* NB: If neither `color` nor `colors` is specified, color attachments are created automatically. */
+    /* A texture or renderbuffer for the color attachment. */
+    color?: REGL.Framebuffer2DAttachment;
+    /* An array of textures or renderbuffers for the color attachments. */
+    colors?: REGL.Framebuffer2DAttachment[];
+    /* Sets the format of the color buffer. Ignored if `color` is specified. Default: 'rgba' */
+    colorFormat?: REGL.FramebufferTextureColorFormat | REGL.RenderbufferColorFormat;
+    /* Sets the type of the color buffer if it is a texture. Default: 'uint8' */
     colorType?: REGL.FramebufferColorDataType;
-    // Sets the number of color buffers. Values > 1 require WEBGL_draw_buffers	1
+    /* Sets the number of color buffers. Values > 1 require WEBGL_draw_buffers. Default: 1 */
     colorCount?: number;
-    // Toggles whether depth/stencil attachments should be in texture. Requires WEBGL_depth_texture	false
+    /* If boolean, toggles the depth attachment. If a renderbuffer or texture, sets the depth attachment. Default: true */
+    depth?: boolean | REGL.Framebuffer2DAttachment;
+    /* If boolean, toggles the stencil attachments. If a renderbuffer or texture, sets the stencil attachment.  Default: true */
+    stencil?: boolean | REGL.Framebuffer2DAttachment;
+    /* If boolean, toggles both the depth and stencil attachments. If a renderbuffer or texture, sets the combined depth/stencil attachment. Default: true */
+    depthStencil?: boolean | REGL.Framebuffer2DAttachment;
+    /* Toggles whether depth/stencil attachments should be in texture. Requires WEBGL_depth_texture. Default: false */
     depthTexture?: boolean;
   }
 
@@ -944,23 +955,36 @@ declare namespace REGL {
   }
 
   interface FramebufferCubeOptions {
-    /** The size of the cube buffer. */
+    /* NB: `shape`, `radius`, and `width`/`height` are alternative (and mutually exclusive) means for setting the size of the cube. */
+    /* Sets the dimensions [width, height] for each face of the cube. Width must equal height. */
+    shape?: [number, number];
+    /* Sets the dimensions `radius` x `radius` for each face of the cube. */
     radius?: number;
-    /** The color buffer attachment. */
+    /* Sets the width dimension for each face of the cube. Must equal `height`. */
+    width?: number;
+    /* Sets the height dimension for each face of the cube. Must equal `width`. */
+    height?: number;
+
+    /* A TextureCube for the color attachment. */
     color?: REGL.TextureCube;
-    /** Format of color buffer to create. */
-    colorFormat?: "rgba"; // TODO Color formats for `FramebufferCube` other that `rgba`?
-    /** Type of color buffer. */
-    colorType?: FramebufferColorDataType;
-    /** Number of color attachments. */
+    /* An array of TextureCubes for the color attachments. */
+    colors?: REGL.TextureCube[];
+    /* Sets the format of the color buffer. */
+    colorFormat?: REGL.FramebufferTextureColorFormat;
+    /* Sets the type of the color buffer. */
+    colorType?: REGL.FramebufferColorDataType;
+    /* Sets the number of color buffers. Values > 1 require WEBGL_draw_buffers. Default: 1 */
     colorCount?: number;
-    /** Depth buffer attachment. */
-    depth?: boolean; // TODO REGL.TextureCube ?
-    /** Stencil buffer attachment. */
-    stencil?: boolean; // TODO REGL.TextureCube ?
-    /** Depth-stencil attachment. */
-    depthStencil?: boolean; // TODO REGL.TextureCube ?
+    /* If boolean, toggles the depth attachment. If texture, sets the depth attachment. Default: true */
+    depth?: boolean | REGL.TextureCube;
+    /* If boolean, toggles the stencil attachment. If texture, sets the stencil attachment. Default: true */
+    stencil?: boolean | REGL.TextureCube;
+    /* If boolean, toggles both the depth and stencil attachments. If texture, sets the combined depth/stencil attachment. Default: true */
+    depthStencil?: boolean | REGL.TextureCube;
   }
+
+  /* `gl.RGBA` */
+  type FramebufferTextureColorFormat = "rgba";
 
   interface FramebufferCube extends Resource {
     /* Reinitializes the FramebufferCube in place using face dimensions 1 x 1. */
@@ -1202,31 +1226,34 @@ declare namespace REGL {
 
   type TextureCubeFaceIndexType = 0 | 1 | 2 | 3 | 4 | 5;
 
-  type RenderbufferFormatType =
-    "rgba4" |
-    "rgb565" |
-    "rgb5 a1" |
+  type RenderbufferFormat =
+    RenderbufferColorFormat |
     "depth" |
     "stencil" |
-    "depth stencil" |
-    "srgba" |
-    "rgba16f" |
-    "rgb16f" |
-    "rgba32f";
+    "depth stencil";
 
-  type FramebufferColorFormatType =
-    "rgba" |
+  type RenderbufferColorFormat =
+    /* `gl.RGBA4` */
     "rgba4" |
+    /* `gl.RGB565` */
     "rgb565" |
+    /* `gl.RGB5_A1` */
     "rgb5 a1" |
+    /* `gl.RGB16F`, requires EXT_color_buffer_half_float */
     "rgb16f" |
+    /* `gl.RGBA16F`, requires EXT_color_buffer_half_float */
     "rgba16f" |
+    /* `gl.RGBA32F`, requires WEBGL_color_buffer_float */
     "rgba32f" |
+    /* `gl.SRGB8_ALPHA8`, requires EXT_sRGB */
     "srgba";
 
   type FramebufferColorDataType =
+    /* `gl.UNSIGNED_BYTE` */
     "uint8" |
+    /* `ext.HALF_FLOAT_OES` (16-bit float), requires OES_texture_half_float */
     "half float" |
+    /* `gl.FLOAT` (32-bit float), requires OES_texture_float */
     "float";
 
   type Props = {

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -420,6 +420,17 @@ declare namespace REGL {
     frag?: string;
 
     /**
+     * Object mapping user-defined keys to user-defined values to be accessed via `DynamicVariable`s
+     * or `DynamicVariableFn`s elsewhere in the `DrawConfig` or in scoped `DrawCommand`s.
+     * Context variables in `regl` are computed before any other parameters and can also be passed
+     * from a scoped command to any sub-commands.
+     * Both `DynamicVariable`s and `DynamicVariableFn`s can be used as values in the context object,
+     * making it possible to define new context properties derived from existing context properties
+     * or from `props`.
+     */
+    context?: REGL.UserContext<ParentContext, OwnContext, Props>,
+
+    /**
      * Object mapping names of uniform variables to their values.
      * To specify uniforms in GLSL structs use the fully qualified path with dot notation.
      *  example: `'nested.value': 5.3`

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -109,9 +109,16 @@ declare namespace REGL {
 
     /* Resource creation */
 
+    /** Creates an empty buffer of length `length`. */
     buffer(length: number): REGL.Buffer;
+    /** Creates a buffer with the provided `data`. */
+    buffer(data: REGL.BufferData): REGL.Buffer;
+    /** Creates a buffer using creation `options`. */
     buffer(options: REGL.BufferOptions): REGL.Buffer;
 
+    /* Creates an Elements object with the provided `data`. */
+    elements(data: REGL.ElementsData): REGL.Elements;
+    /* Creates an Elements object using creation `options`. */
     elements(options: REGL.ElementsOptions): REGL.Elements;
 
     /**
@@ -579,45 +586,126 @@ declare namespace REGL {
    * A *resource* is a handle to a GPU resident object, like a texture, FBO or buffer.
    */
   interface Resource {
+    /** relevant WebGL API: `gl.deleteBuffer` */
     destroy(): void;
   }
 
-  interface BufferOptions {
-    data?: REGL.BufferDataType | null;
-    length?: number;
-    usage?: REGL.BufferUsageHintType;
-    type?: REGL.BufferDataTypeType;
-  }
-
   interface Buffer extends Resource {
+    /**
+     * Wraps a WebGL array buffer object.
+     */
     readonly stats: {
-        /** The size of the buffer in bytes. */
-        size: number;
+      /** The size of the buffer in bytes. */
+      size: number;
     }
 
     /**
      * Reinitializes the buffer with the new content.
+     * Relevant WebGL API: `gl.bufferData`
      */
+    (data: REGL.BufferData): void;
     (options: REGL.BufferOptions): void;
 
-    subdata(data: REGL.BufferDataType, offset?: number): void;
+    /**
+     * Update a portion of the buffer, optionally starting at byte offset `offset`.
+     * Relevant WebGL API: `gl.bufferSubData`
+     */
+    subdata(data: REGL.BufferData, offset?: number): void;
+    subdata(options: REGL.BufferOptions, offset?: number): void;
+  }
+
+  interface BufferOptions {
+    /** The data for the vertex buffer. Default: null */
+    data?: REGL.BufferData | null;
+    /** If `data` is `null` or not present reserves space for the buffer. Default: 0 */
+    length?: number;
+    /** Sets array buffer usage hint. Default: 'static' */
+    usage?: REGL.BufferUsageHint;
+    /** Data type for vertex buffer. Default: 'uint8' */
+    type?: REGL.BufferDataType;
+  }
+
+  type BufferData =
+    number[] |
+    number[][] |
+    Uint8Array |
+    Int8Array |
+    Uint16Array |
+    Int16Array |
+    Uint32Array |
+    Int32Array |
+    Float32Array;
+
+  type BufferUsageHint =
+    /** gl.DRAW_STATIC */
+    "static" |
+    /** gl.DYNAMIC_DRAW */
+    "dynamic" |
+    /** gl.STREAM_DRAW */
+    "stream";
+
+  type BufferDataType =
+    /** gl.UNSIGNED_BYTE */
+    "uint8" |
+    /** gl.BYTE */
+    "int8" |
+    /** gl.UNSIGNED_SHORT */
+    "uint16" |
+    /** gl.SHORT */
+    "int16" |
+    /** gl.UNSIGNED_INT */
+    "uint32" |
+    /** gl.INT */
+    "int32" |
+    /** gl.FLOAT */
+    "float32" | "float";
+
+  interface Elements extends Resource {
+    /**
+     * Wraps a WebGL element array buffer object.
+     */
+
+    /**
+     * Reinitializes the element buffer with the new content.
+     * Relevant WebGL API: `gl.bufferData`
+     */
+    (data: ElementsData): void;
+    (options: ElementsOptions): void;
+
+    /**
+     * Update a portion of the element buffer, optionally starting at byte offset `offset`.
+     * Relevant WebGL API: `gl.bufferSubData`
+     */
+    subdata(data: ElementsData, offset?: number): void;
+    subdata(options: ElementsOptions, offset?: number): void;
   }
 
   interface ElementsOptions {
-    data?: REGL.BufferDataType;
-    usage?: REGL.BufferUsageHintType;
+    /** The data of the element buffer. (Default: null) */
+    data?: REGL.ElementsData | null;
+    /** Usage hint (see gl.bufferData). (Default: 'static') */
+    usage?: REGL.BufferUsageHint;
+    /** Length of the element buffer in bytes. (Default: 0, or inferred from `data`) */
     length?: number;
+    /** Default primitive type for element buffer. (Default: 0, or inferred from `data`) */
     primitive?: REGL.PrimitiveType;
-    type?: REGL.ElementsDataTypeType;
+    /** Data type for element buffer. (Default: 'uint8') */
+    type?: REGL.ElementsDataType;
+    /** Vertex count for element buffer. (Default: 0, or inferred from `data`) */
     count?: number;
   }
 
-  interface Elements extends Resource {
-    // TODO stats: { size: number } ???
-    (data: ElementsOptions): void;
+  type ElementsData =
+    number[] |
+    number[][] |
+    Uint8Array |
+    Uint16Array |
+    Uint32Array;
 
-    subdata(data: ElementsOptions, offset?: number): void;
-  }
+  type ElementsDataType =
+    "uint8" |
+    "uint16" |
+    "uint32";
 
   interface Texture2DOptions {
     /** Sets `width`, `height` and, optionally, `channels`. */
@@ -961,35 +1049,6 @@ declare namespace REGL {
     "triangles" |
     "triangle strip" |
     "triangle fan";
-
-  type BufferDataType =
-    (number | number[])[] |
-    Uint8Array |
-    Int8Array |
-    Uint16Array |
-    Int16Array |
-    Uint32Array |
-    Int32Array |
-    Float32Array; // | REGL.Buffer
-
-  type BufferUsageHintType =
-    "static" |
-    "dynamic" |
-    "stream";
-
-  type BufferDataTypeType =
-    "uint8" |
-    "int8" |
-    "uint16" |
-    "int16" |
-    "uint32" |
-    "int32" |
-    "float32" | "float";
-
-  type ElementsDataTypeType =
-    "uint8" |
-    "uint16" |
-    "uint32"; // | REGL.Elements
 
   // TODO Cover all possible things that could be used to create/update a texture
   // Possible candidates: HTMLImageElement, HTMLVideoElement, NDArray,

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -792,7 +792,6 @@ declare namespace REGL {
     resize(radius: number): void;
   }
 
-  // TODO Revise the types of `REGL.Limits` fields
   interface Limits {
     /** An array of bits depths for the red, green, blue and alpha channels */
     colorBits: [number, number, number, number];
@@ -801,7 +800,7 @@ declare namespace REGL {
     /** Bit depth of stencil buffer */
     stencilBits: number;
     /** gl.SUBPIXEL_BITS */
-    subpixelBits: any;
+    subpixelBits: number;
     /** A list of all supported extensions */
     extensions: string[];
     /** Maximum number of anisotropic filtering samples */
@@ -811,31 +810,31 @@ declare namespace REGL {
     /** Maximum number of color attachments */
     maxColorAttachments: number;
     /** gl.ALIASED_POINT_SIZE_RANGE */
-    pointSizeDims: any;
+    pointSizeDims: Float32Array;
     /** gl.ALIASED_LINE_WIDTH_RANGE */
-    lineWidthDims: any;
+    lineWidthDims: Float32Array;
     /** gl.MAX_VIEWPORT_DIMS */
-    maxViewportDims: any;
+    maxViewportDims: Int32Array;
     /** gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS */
-    maxCombinedTextureUnits: any;
+    maxCombinedTextureUnits: number;
     /** gl.MAX_CUBE_MAP_TEXTURE_SIZE */
-    maxCubeMapSize: any;
+    maxCubeMapSize: number;
     /** gl.MAX_RENDERBUFFER_SIZE */
-    maxRenderbufferSize: any;
+    maxRenderbufferSize: number;
     /** gl.MAX_TEXTURE_IMAGE_UNITS */
-    maxTextureUnits: any;
+    maxTextureUnits: number;
     /** gl.MAX_TEXTURE_SIZE */
-    maxTextureSize: any;
+    maxTextureSize: number;
     /** gl.MAX_VERTEX_ATTRIBS */
-    maxAttributes: any;
+    maxAttributes: number;
     /** gl.MAX_VERTEX_UNIFORM_VECTORS */
-    maxVertexUniforms: any;
+    maxVertexUniforms: number;
     /** gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS */
-    maxVertexTextureUnits: any;
+    maxVertexTextureUnits: number;
     /** gl.MAX_VARYING_VECTORS */
-    maxVaryingVectors: any;
+    maxVaryingVectors: number;
     /** gl.MAX_FRAGMENT_UNIFORM_VECTORS */
-    maxFragmentUniforms: any;
+    maxFragmentUniforms: number;
     /** gl.SHADING_LANGUAGE_VERSION */
     glsl: string;
     /** gl.RENDERER */

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -867,19 +867,6 @@ declare namespace REGL {
     subimage(face: REGL.TextureCubeFaceIndexType, data: TextureImageData, x?: number, y?: number, level?: number);
   }
 
-  interface RenderbufferOptions {
-    /** Sets the internal format of the render buffer (Default `'rgba4'`) */
-    format?: REGL.RenderbufferFormat;
-    /** Sets the width of the render buffer in pixels. (Default `1`) */
-    width?: number;
-    /** Sets the height of the render buffer in pixels. (Default `1`) */
-    height?: number;
-    /** Alias for `[width, height]`. (Default `[1, 1]`) */
-    shape?: [number, number];
-    /** Simultaneously sets width and height. (Default `1`) */
-    radius?: number;
-  }
-
   interface Renderbuffer extends Resource {
     readonly stats: {
         /** Size of the renderbuffer in bytes. */
@@ -900,7 +887,60 @@ declare namespace REGL {
     resize(width: number, height: number): void;
   }
 
-  type Framebuffer2DAttachment = REGL.Texture2D | REGL.Renderbuffer;
+  interface RenderbufferOptions {
+    /** Sets the internal format of the render buffer (Default `'rgba4'`) */
+    format?: REGL.RenderbufferFormat;
+    /** Sets the width of the render buffer in pixels. (Default `1`) */
+    width?: number;
+    /** Sets the height of the render buffer in pixels. (Default `1`) */
+    height?: number;
+    /** Alias for `[width, height]`. (Default `[1, 1]`) */
+    shape?: [number, number];
+    /** Simultaneously sets width and height. (Default `1`) */
+    radius?: number;
+  }
+
+  type RenderbufferFormat =
+    RenderbufferColorFormat |
+    "depth" |
+    "stencil" |
+    "depth stencil";
+
+  type RenderbufferColorFormat =
+    /* `gl.RGBA4` */
+    "rgba4" |
+    /* `gl.RGB565` */
+    "rgb565" |
+    /* `gl.RGB5_A1` */
+    "rgb5 a1" |
+    /* `gl.RGB16F`, requires EXT_color_buffer_half_float */
+    "rgb16f" |
+    /* `gl.RGBA16F`, requires EXT_color_buffer_half_float */
+    "rgba16f" |
+    /* `gl.RGBA32F`, requires WEBGL_color_buffer_float */
+    "rgba32f" |
+    /* `gl.SRGB8_ALPHA8`, requires EXT_sRGB */
+    "srgba";
+
+  interface Framebuffer extends Resource {
+    /* Reinitializes the Framebuffer in place using dimensions: 1 x 1. */
+    (): void;
+    /* Reinitializes the Framebuffer in place using dimensions: `radius` x `radius`. */
+    (radius: number): void;
+    /* Reinitializes the Framebuffer in place using dimensions: `width` x `height`. */
+    (width: number, height: number): void;
+    /* Reinitializes the Framebuffer in place using creation `options`. */
+    (options: FramebufferOptions): void;
+
+    /* Framebuffer binding */
+
+    /* Binds a framebuffer directly. This is a short cut for creating a command which sets the framebuffer. */
+    use(body: CommandBodyFn): void;
+
+    /* Resizes the Framebuffer and all its attachments. */
+    resize(radius: number): void;
+    resize(width: number, height: number): void;
+  }
 
   interface FramebufferOptions {
     /* NB: `shape`, `radius`, and `width`/`height` are alternative (and mutually exclusive) means for setting the size of the framebuffer. */
@@ -934,24 +974,18 @@ declare namespace REGL {
     depthTexture?: boolean;
   }
 
-  interface Framebuffer extends Resource {
-    /* Reinitializes the Framebuffer in place using dimensions: 1 x 1. */
+  type Framebuffer2DAttachment = REGL.Texture2D | REGL.Renderbuffer;
+
+  interface FramebufferCube extends Resource {
+    /* Reinitializes the FramebufferCube in place using face dimensions 1 x 1. */
     (): void;
-    /* Reinitializes the Framebuffer in place using dimensions: `radius` x `radius`. */
+    /* Reinitializes the FramebufferCube in place using face dimensions `radius` x `radius`. */
     (radius: number): void;
-    /* Reinitializes the Framebuffer in place using dimensions: `width` x `height`. */
-    (width: number, height: number): void;
-    /* Reinitializes the Framebuffer in place using creation `options`. */
-    (options: FramebufferOptions): void;
+    /* Reinitializes the FramebufferCube in place using creation `options`. */
+    (options: FramebufferCubeOptions): void;
 
-    /* Framebuffer binding */
-
-    /* Binds a framebuffer directly. This is a short cut for creating a command which sets the framebuffer. */
-    use(body: CommandBodyFn): void;
-
-    /* Resizes the Framebuffer and all its attachments. */
+    /* Resizes the FramebufferCube and all its attachments. */
     resize(radius: number): void;
-    resize(width: number, height: number): void;
   }
 
   interface FramebufferCubeOptions {
@@ -986,17 +1020,13 @@ declare namespace REGL {
   /* `gl.RGBA` */
   type FramebufferTextureColorFormat = "rgba";
 
-  interface FramebufferCube extends Resource {
-    /* Reinitializes the FramebufferCube in place using face dimensions 1 x 1. */
-    (): void;
-    /* Reinitializes the FramebufferCube in place using face dimensions `radius` x `radius`. */
-    (radius: number): void;
-    /* Reinitializes the FramebufferCube in place using creation `options`. */
-    (options: FramebufferCubeOptions): void;
-
-    /* Resizes the FramebufferCube and all its attachments. */
-    resize(radius: number): void;
-  }
+  type FramebufferColorDataType =
+    /* `gl.UNSIGNED_BYTE` */
+    "uint8" |
+    /* `ext.HALF_FLOAT_OES` (16-bit float), requires OES_texture_half_float */
+    "half float" |
+    /* `gl.FLOAT` (32-bit float), requires OES_texture_float */
+    "float";
 
   interface Limits {
     /** An array of bits depths for the red, green, blue and alpha channels */
@@ -1225,36 +1255,6 @@ declare namespace REGL {
   type TextureUnpackAlignmentType = 1 | 2 | 4 | 8;
 
   type TextureCubeFaceIndexType = 0 | 1 | 2 | 3 | 4 | 5;
-
-  type RenderbufferFormat =
-    RenderbufferColorFormat |
-    "depth" |
-    "stencil" |
-    "depth stencil";
-
-  type RenderbufferColorFormat =
-    /* `gl.RGBA4` */
-    "rgba4" |
-    /* `gl.RGB565` */
-    "rgb565" |
-    /* `gl.RGB5_A1` */
-    "rgb5 a1" |
-    /* `gl.RGB16F`, requires EXT_color_buffer_half_float */
-    "rgb16f" |
-    /* `gl.RGBA16F`, requires EXT_color_buffer_half_float */
-    "rgba16f" |
-    /* `gl.RGBA32F`, requires WEBGL_color_buffer_float */
-    "rgba32f" |
-    /* `gl.SRGB8_ALPHA8`, requires EXT_sRGB */
-    "srgba";
-
-  type FramebufferColorDataType =
-    /* `gl.UNSIGNED_BYTE` */
-    "uint8" |
-    /* `ext.HALF_FLOAT_OES` (16-bit float), requires OES_texture_half_float */
-    "half float" |
-    /* `gl.FLOAT` (32-bit float), requires OES_texture_float */
-    "float";
 
   type Props = {
     [name: string]: PropType;

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -328,14 +328,24 @@ declare namespace REGL {
     frag?: string;
 
     /**
+     * Object mapping names of uniform variables to their values.
+     * To specify uniforms in GLSL structs use the fully qualified path with dot notation.
+     *  example: `'nested.value': 5.3`
+     * To specify uniforms in GLSL arrays use the fully qualified path with bracket notation.
+     *  example: `'colors[0]': [0, 1, 0, 1]`
+     *
      * Related WebGL APIs
      *
      * - gl.getUniformLocation
      * - gl.uniform
      */
-    uniforms?: REGL.Props;
+    uniforms?: {
+      [name: string]: REGL.Uniform;
+    };
 
     /**
+     * Object mapping names of attribute variables to their values.
+     *
      * Related WebGL APIs
      *
      * - gl.vertexAttribPointer
@@ -477,7 +487,45 @@ declare namespace REGL {
     viewport?: REGL.ViewportOptions;
   }
 
-  interface Attribute {
+  type PrimitiveType =
+    /** gl.POINTS */
+    "points" |
+    /** gl.LINES */
+    "lines" |
+    /** gl.LINE_STRIP */
+    "line strip" |
+    /** gl.LINE_LOOP */
+    "line loop" |
+    /** gl.TRIANGLES */
+    "triangles" |
+    /** gl.TRIANGLE_STRIP */
+    "triangle strip" |
+    /** gl.TRIANGLE_FAN */
+    "triangle fan";
+
+  type Uniform =
+    DynamicVariable |
+    DynamicVariableFn |
+    boolean |
+    number |
+    boolean[] |
+    number[] |
+    Float32Array |
+    Int32Array;
+
+  type Attribute =
+    DynamicVariable |
+    DynamicVariableFn |
+    ConstantAttribute |
+    AttributeConfig |
+    REGL.Buffer |
+    REGL.BufferData;
+
+  interface ConstantAttribute {
+    constant: number | number[];
+  }
+
+  interface AttributeConfig {
     /** A REGLBuffer wrapping the buffer object. (Default: null) */
     buffer?: REGL.Buffer;
     /** The offset of the vertexAttribPointer in bytes. (Default: 0) */
@@ -1040,15 +1088,6 @@ declare namespace REGL {
   type FaceWindingType =
     "cw" |
     "ccw";
-
-  type PrimitiveType =
-    "points" |
-    "lines" |
-    "line strip" |
-    "line loop" |
-    "triangles" |
-    "triangle strip" |
-    "triangle fan";
 
   // TODO Cover all possible things that could be used to create/update a texture
   // Possible candidates: HTMLImageElement, HTMLVideoElement, NDArray,

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -361,15 +361,15 @@ declare namespace REGL {
     /* Drawing */
 
     /**
-     * Sets the primitive type.
+     * Sets the primitive type. (Default: 'triangles', or inferred from `elements`)
      */
     primitive?: REGL.PrimitiveType;
     /**
-     * Number of vertices to draw.
+     * Number of vertices to draw. (Default: 0, or inferred from `elements`)
      */
     count?: number;
     /**
-     * Offset of primitives to draw.
+     * Offset of primitives to draw. (Default: 0, or inferred from `elements`)
      */
     offset?: number;
     /**
@@ -381,6 +381,7 @@ declare namespace REGL {
     /**
      * Element array buffer. (Default: `null`)
      *
+     * Elements must be either an instance of REGL.Elements or else the arguments to REGL.Elements.
      * If `elements` is specified while `primitive`, `count` and `offset` are not,
      * then these values may be inferred from the state of the element array buffer.
      */
@@ -536,7 +537,7 @@ declare namespace REGL {
     normalized?: boolean;
     /** The size of the vertex attribute. (Default: Inferred from shader) */
     size?: number;
-    /** Sets gl.vertexAttribDivisorANGLE. (Default: 0) */
+    /** Sets gl.vertexAttribDivisorANGLE. Only supported if the ANGLE_instanced_arrays extension is available. (Default: 0) */
     divisor?: number;
   }
 

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -66,7 +66,6 @@ declare namespace REGL {
    */
   export interface Regl {
     readonly attributes: WebGLContextAttributes;
-    readonly contextLost: boolean;
     readonly _gl: WebGLRenderingContext;
     readonly limits: REGL.Limits;
     readonly stats: REGL.Stats;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "compilerOptions": {
+    "noEmit": true,
     "lib": ["dom", "es6"],
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
+    "strict": true,
     "forceConsistentCasingInFileNames": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+      "lib": ["dom", "es6"],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "forceConsistentCasingInFileNames": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-      "lib": ["dom", "es6"],
-      "noImplicitAny": true,
-      "noImplicitThis": true,
-      "strictNullChecks": true,
-      "strictFunctionTypes": true,
-      "forceConsistentCasingInFileNames": true
+    "lib": ["dom", "es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
This PR resolves #238.

In addition to adding a type declaration file, `regl.d.ts`, I've ported some of the code examples (those that appear in http://regl.party/examples) to TypeScript, to demonstrate how the types could be used. I also made some updates to the API docs based on my research into the functionality of the library. I'm interested in @stevebest's work generating documentation from the type declaration file, but I haven't implemented that here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/457)
<!-- Reviewable:end -->
