### PR TITLE
Fix element state initialization

### DIFF
--- a/regl.js
+++ b/regl.js
@@ -86,7 +86,6 @@ module.exports = function wrapREGL (args) {
   }
 
   var limits = wrapLimits(gl, extensions)
-  var elementState = wrapElements(gl, extensions, bufferState, stats)
   var attributeState = wrapAttributes(
     gl,
     extensions,
@@ -97,6 +96,7 @@ module.exports = function wrapREGL (args) {
     stats,
     config,
     attributeState)
+  var elementState = wrapElements(gl, extensions, bufferState, stats)
   var shaderState = wrapShaders(gl, stringStore, stats, config)
   var textureState = wrapTextures(
     gl,


### PR DESCRIPTION
Hi,
As pointed out by @nassosyian in #456, drawing with elements and several of the examples that use elements are currently broken. This is a small patch that fixes the initialization order error.

Thank you for all your contributions, regl is great!