### PR TITLE
Add support for ImageBitmap

### DIFF
--- a/API.md
+++ b/API.md
@@ -1687,6 +1687,17 @@ image.onload = function () {
   var imageTexture = regl.texture(image)
 }
 
+/* From an ImageBitmap
+ * This is only useful when loading many images, as bitmaps can be created asynchronously
+ * and will transfer faster than an image element.
+ */
+var image = new Image()
+image.src = 'http://mydomain.com/myimage.png'
+image.onload = function () {
+  createImageBitmap(image).then(function (bitmap) {
+    var imageTexture = regl.texture(bitmap)
+  }
+}
 
 // From a canvas
 var canvas = document.createElement(canvas)
@@ -1717,6 +1728,7 @@ A data source from an image can be one of the following types:
 | Array                       | Interpreted as array of pixel values with type based on the input type                                  |
 | `ndarray`                   | Any object with a `shape, stride, offset, data` (see [SciJS ndarray](https://github.com/scijs/ndarray)) |
 | Image                       | An HTML image element                                                                                   |
+| ImageBitmap                 | An ImageBitmap object                                                                                   |
 | Video                       | An HTML video element                                                                                   |
 | Canvas                      | A canvas element                                                                                        |
 | Context 2D                  | A canvas 2D context                                                                                     |

--- a/lib/texture.js
+++ b/lib/texture.js
@@ -133,12 +133,14 @@ function objectName (str) {
 
 var CANVAS_CLASS = objectName('HTMLCanvasElement')
 var CONTEXT2D_CLASS = objectName('CanvasRenderingContext2D')
+var BITMAP_CLASS = objectName('ImageBitmap')
 var IMAGE_CLASS = objectName('HTMLImageElement')
 var VIDEO_CLASS = objectName('HTMLVideoElement')
 
 var PIXEL_CLASSES = Object.keys(dtypes).concat([
   CANVAS_CLASS,
   CONTEXT2D_CLASS,
+  BITMAP_CLASS,
   IMAGE_CLASS,
   VIDEO_CLASS
 ])
@@ -203,6 +205,10 @@ function isCanvasElement (object) {
 
 function isContext2D (object) {
   return classString(object) === CONTEXT2D_CLASS
+}
+
+function isBitmap (object) {
+  return classString(object) === BITMAP_CLASS
 }
 
 function isImageElement (object) {
@@ -761,6 +767,11 @@ module.exports = function createTextureSet (
       }
       image.width = image.element.width
       image.height = image.element.height
+      image.channels = 4
+    } else if (isBitmap(data)) {
+      image.element = data
+      image.width = data.width
+      image.height = data.height
       image.channels = 4
     } else if (isImageElement(data)) {
       image.element = data


### PR DESCRIPTION
Supporting ImageBitmaps allows performant transfers of multiple large
textures. Textures will transfer synchronously (over texImage2D),
and converting some or all to bitmaps asynchronously before transferring
will reduce transfer time.

This PR adds support in lib/texture.js, and documents it in API.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/470)
<!-- Reviewable:end -->
