### PR TITLE
add support of rgb format for fbo texture

### DIFF
--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -24,11 +24,13 @@ var GL_HALF_FLOAT_OES = 0x8D61
 var GL_UNSIGNED_BYTE = 0x1401
 var GL_FLOAT = 0x1406
 
+var GL_RGB = 0x1907
 var GL_RGBA = 0x1908
 
 var GL_DEPTH_COMPONENT = 0x1902
 
 var colorTextureFormatEnums = [
+  GL_RGB,
   GL_RGBA
 ]
 
@@ -36,6 +38,7 @@ var colorTextureFormatEnums = [
 // the number of channels
 var textureFormatChannels = []
 textureFormatChannels[GL_RGBA] = 4
+textureFormatChannels[GL_RGB] = 3
 
 // for every texture type, store
 // the size in bytes.

--- a/test/framebuffer-simple.js
+++ b/test/framebuffer-simple.js
@@ -397,6 +397,31 @@ tape('framebuffer', function (t) {
   checkContents(testFBO1, [255, 0, 0, 255], 'batch fbo 1')
   checkContents(testFBO2, [0, 0, 255, 255], 'batch fbo 2')
 
+  if (typeof document !== 'undefined') {
+    // test for #476, add support of rgb texture
+    // FIXME ok in browser, but still failed in headless-gl
+    var rgbTex = regl.texture({
+      width: 4,
+      height: 4,
+      format: 'rgb',
+      type: 'uint8'
+    })
+
+    var rgbFBO = regl.framebuffer({
+      color: [rgbTex]
+    })
+    setFramebufferStatic({
+      framebuffer: rgbFBO
+    }, function () {
+      clearCheck({
+        width: 4,
+        height: 4,
+        framebuffer: rgbFBO,
+        color: [0, 255, 0, 255]
+      }, 'fbo with rgb texture')
+    })
+  }
+
   regl.destroy()
   t.equals(gl.getError(), 0, 'error ok')
   createContext.destroy(gl)


### PR DESCRIPTION
Add support of rgb format for fbo texture, which is not supported now, as below:
```js
const texture = regl.texture({
        width, height,
        format : 'rgb' // only support rgba now
});

const fbo = regl.framebuffer({
       color : texture,
       depth : true
});
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/476)
<!-- Reviewable:end -->
