### PR TITLE
Fix SHADER_NAME_B64 decoding Base64

### DIFF
--- a/lib/util/check.js
+++ b/lib/util/check.js
@@ -3,15 +3,15 @@
 // Statements for the form `check.someProcedure(...)` get removed by
 // a browserify transform for optimized/minified bundles.
 //
-/* globals btoa */
+/* globals atob */
 var isTypedArray = require('./is-typed-array')
 var extend = require('./extend')
 
-// only used for extracting shader names.  if btoa not present, then errors
+// only used for extracting shader names.  if atob not present, then errors
 // will be slightly crappier
 function decodeB64 (str) {
-  if (typeof btoa !== 'undefined') {
-    return btoa(str)
+  if (typeof atob !== 'undefined') {
+    return atob(str)
   }
   return 'base64:' + str
 }


### PR DESCRIPTION
The shader debugger which picks up base64 encoded shader names is encoding (btoa) instead of decoding (atob) the name string. Trivial fix.

(**a**scii-**to**-**b**inary)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/477)
<!-- Reviewable:end -->
