### PR TITLE
fix npm run test-browser

### DIFF
--- a/test/util/browser.js
+++ b/test/util/browser.js
@@ -46,4 +46,4 @@ function updateDOM () {
   pendingRaf = null
 }
 
-require('./index')
+require('../index')


### PR DESCRIPTION
fix a typo failing `test-browser`