### PR TITLE
Report a safari-specific test failure without halting all tests

### DIFF
--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -519,24 +519,9 @@ tape('framebuffer parsing', function (t) {
       }
     }
 
-    checkProperties(
-      regl.framebuffer(fboArgs),
-      {
-        width: 10,
-        height: 10,
-        color: [expected],
-        depthStencil: {
-          target: gl.RENDERBUFFER,
-          format: gl.DEPTH_STENCIL
-        }
-      },
-      'for colorFormat=' + testCase.colorFormat + (testCase.tex ? (' and colorType=' + testCase.colorType) : ''))
-
-    // if not renderbuffer, also do the test for cubic fbo.
-    if (testCase.tex) {
-      console.log()
-      checkPropertiesCube(
-        regl.framebufferCube(fboArgs),
+    try {
+      checkProperties(
+        regl.framebuffer(fboArgs),
         {
           width: 10,
           height: 10,
@@ -546,7 +531,29 @@ tape('framebuffer parsing', function (t) {
             format: gl.DEPTH_STENCIL
           }
         },
-        'cubic fbo, for colorFormat=' + testCase.colorFormat + (testCase.tex ? (' and colorType=' + testCase.colorType) : ''))
+        'for colorFormat=' + testCase.colorFormat + (testCase.tex ? (' and colorType=' + testCase.colorType) : ''))
+    } catch (e) {
+        t.notOk(true, e.toString());
+    }
+
+    // if not renderbuffer, also do the test for cubic fbo.
+    if (testCase.tex) {
+      try {
+        checkPropertiesCube(
+          regl.framebufferCube(fboArgs),
+          {
+            width: 10,
+            height: 10,
+            color: [expected],
+            depthStencil: {
+              target: gl.RENDERBUFFER,
+              format: gl.DEPTH_STENCIL
+            }
+          },
+          'cubic fbo, for colorFormat=' + testCase.colorFormat + (testCase.tex ? (' and colorType=' + testCase.colorType) : ''))
+      } catch (e) {
+        t.notOk(true, e.toString());
+      }
     }
   })
 

--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -533,7 +533,7 @@ tape('framebuffer parsing', function (t) {
         },
         'for colorFormat=' + testCase.colorFormat + (testCase.tex ? (' and colorType=' + testCase.colorType) : ''))
     } catch (e) {
-        t.notOk(true, e.toString());
+      t.notOk(true, e.toString())
     }
 
     // if not renderbuffer, also do the test for cubic fbo.
@@ -552,7 +552,7 @@ tape('framebuffer parsing', function (t) {
           },
           'cubic fbo, for colorFormat=' + testCase.colorFormat + (testCase.tex ? (' and colorType=' + testCase.colorType) : ''))
       } catch (e) {
-        t.notOk(true, e.toString());
+        t.notOk(true, e.toString())
       }
     }
   })


### PR DESCRIPTION
As mentioned in #479, there's a safari-specific half float bug that brings tests to a halt. Rather than a new failure, I believe this is instead the result of a new check for behavior that *does* seem broken in safari: https://github.com/regl-project/regl/commit/75730b6098985260438c16afc6d9a933bc7f9f2c#diff-6d2e0d9813eb0b2330521d6a391021d3R169

This PR doesn't fix anything (Babylon, for one, just [detects safari and reverts from half_float to float](https://github.com/BabylonJS/Babylon.js/pull/2509), I believe) but instead triggers a test failure that doesn't halt all tests.

In particular, it just wraps the test in a try/catch and reports a failure if it catches anything.