### PR TITLE
Fix vertexAttrib4f constant length conditional

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1812,7 +1812,7 @@ module.exports = function reglCore (
           '}else{',
           CUTE_COMPONENTS.map(function (name, i) {
             return (
-              result[name] + '=' + VALUE + '.constant.length>=' + i +
+              result[name] + '=' + VALUE + '.constant.length>' + i +
               '?' + VALUE + '.constant[' + i + ']:0;'
             )
           }).join(''),


### PR DESCRIPTION
While debugging code generation output, I noticed a subtle off-by-one error that probably doesn't have much of an effect, but which seems incorrect nonetheless:

<img width="616" alt="screen shot 2018-05-16 at 3 31 25 pm" src="https://user-images.githubusercontent.com/572717/40147393-4ec57fa6-591e-11e8-8639-789f6f0f2bde.png">

The issue is that `>=` should instead be `>`. The incorrect version passes `undefined` to `vertexAttrib4f` instead of the zero fallback—though it maybe *does* actually use a zero fallback internally anyway.

To unpack that, `[1]` has length 1. The second conditional passes and causes the first *two* entries to use the array-specified value, which is incorrect since the second entry is then undefined.