### PR TITLE
Fix exports in pool

### DIFF
--- a/lib/util/pool.js
+++ b/lib/util/pool.js
@@ -93,7 +93,9 @@ function createPool () {
   }
 }
 
-module.exports = createPool()
+var pool = createPool()
 
 // zero pool for initial zero data
-module.exports.zero = createPool()
+pool.zero = createPool()
+
+module.exports = pool


### PR DESCRIPTION
This code in `lib/util/pool.js`:

```javascript
module.exports = createPool()
// zero pool for initial zero data
module.exports.zero = createPool()
```

gets bundled by rollup as:

```javascript
var pool = createPool();
// zero pool for initial zero data
module.exports.zero = createPool();
```

As a result, `pool.zero` is undefined. At its core this seems like a rollup "bug" that results from the flat namespace not unpacking properties added to exports after the fact. This PR assigns `pool` to a variable, than adds `zero`, *then* exports.

The rollup'd output is:

```javascript
var pool = createPool();
// zero pool for initial zero data
pool.zero = createPool();
```

(though I have *not* rebuilt `dist/` as part of this PR.)

I checked and don't see any other occurrences of this in the codebase.

/cc @dy 