### PR TITLE
Fix a bug with framebuffer binding not working recursively in contexts

### DIFF
--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -338,7 +338,8 @@ module.exports = function wrapFBOState (
         statusCode[status])
     }
 
-    gl.bindFramebuffer(GL_FRAMEBUFFER, framebufferState.next)
+
+    gl.bindFramebuffer(GL_FRAMEBUFFER, framebufferState.next ? framebufferState.next.framebuffer : null)
     framebufferState.cur = framebufferState.next
 
     // FIXME: Clear error code here.  This is a work around for a bug in


### PR DESCRIPTION
The case where the next framebuffer is not the drawing buffer wasn't handled correctly.