### PR TITLE
Disable logging styles for error reporting in chrome

### DIFF
--- a/lib/util/check.js
+++ b/lib/util/check.js
@@ -7,6 +7,8 @@
 var isTypedArray = require('./is-typed-array')
 var extend = require('./extend')
 
+var endl = '\n'
+
 // only used for extracting shader names.  if atob not present, then errors
 // will be slightly crappier
 function decodeB64 (str) {
@@ -258,7 +260,7 @@ function checkShaderError (gl, shader, source, type, command) {
       file.lines.forEach(function (line) {
         if (line.errors.length > 0) {
           push(leftPad(line.number, 4) + '|  ', 'background-color:yellow; font-weight:bold')
-          push(line.line + '\n', 'color:red; background-color:yellow; font-weight:bold')
+          push(line.line + endl, 'color:red; background-color:yellow; font-weight:bold')
 
           // try to guess token
           var offset = 0
@@ -279,17 +281,17 @@ function checkShaderError (gl, shader, source, type, command) {
             }
 
             push(leftPad('| ', 6))
-            push(leftPad('^^^', offset + 3) + '\n', 'font-weight:bold')
+            push(leftPad('^^^', offset + 3) + endl, 'font-weight:bold')
             push(leftPad('| ', 6))
-            push(message + '\n', 'font-weight:bold')
+            push(message + endl, 'font-weight:bold')
           })
-          push(leftPad('| ', 6) + '\n')
+          push(leftPad('| ', 6) + endl)
         } else {
           push(leftPad(line.number, 4) + '|  ')
-          push(line.line + '\n', 'color:red')
+          push(line.line + endl, 'color:red')
         }
       })
-      if (typeof document !== 'undefined') {
+      if (typeof document !== 'undefined' && !window.chrome) {
         styles[0] = strings.join('%c')
         console.log.apply(console, styles)
       } else {
@@ -311,11 +313,11 @@ function checkLinkError (gl, program, fragShader, vertShader, command) {
       vertParse[0].name + '", and fragment shader "' + fragParse[0].name + '"'
 
     if (typeof document !== 'undefined') {
-      console.log('%c' + header + '\n%c' + errLog,
+      console.log('%c' + header + endl + '%c' + errLog,
         'color:red;text-decoration:underline;font-weight:bold',
         'color:red')
     } else {
-      console.log(header + '\n' + errLog)
+      console.log(header + endl + errLog)
     }
     check.raise(header)
   }


### PR DESCRIPTION
Error logs don't work on chrome which is extremely annoying.  Will keep this turned off until they get fixed.