### PR TITLE
Fix type def TextureImage2D.subimage overload.

### DIFF
--- a/regl.d.ts
+++ b/regl.d.ts
@@ -1191,7 +1191,7 @@ declare namespace REGL {
     /* Replaces the area at offset `x` (default: 0), `y` (default: 0), with `data`. */
     subimage(data: REGL.TextureImageData, x?: number, y?: number, level?: number): REGL.Texture2D;
     /* Replaces a subset of the image using creation `options`. */
-    subimage(options: Texture2DOptions): REGL.Texture2D;
+    subimage(options: Texture2DOptions, x?: number, y?: number, level?: number): REGL.Texture2D;
 
     /** Resizes the texture to `radius` x `radius`. */
     resize(radius: number): REGL.Texture2D;


### PR DESCRIPTION
This PR corrects the signature of the function `Texture2D.subimage`. Optional args `x`, `y`, and `level` can be provided whether the first argument is `TextureImageData` or `Texture2DOptions`. Verified that this works at runtime.