### PR TITLE
Fix allocating ArrayBuffer for very large textures, fixes #498

### DIFF
--- a/lib/util/pool.js
+++ b/lib/util/pool.js
@@ -17,15 +17,6 @@ function nextPow8 (v) {
   return 0
 }
 
-function nextPow16 (v) {
-  for (var i = 16; i <= (1 << 28); i *= 16) {
-    if (v <= i) {
-      return i
-    }
-  }
-  return 0
-}
-
 function log2 (v) {
   var r, shift
   r = (v > 0xFFFF) << 4
@@ -40,18 +31,14 @@ function log2 (v) {
 }
 
 function createPool () {
-  var bufferPool16 = loop(8, function () {
-    return []
-  })
-  var bufferPool8 = loop(11, function () {
+  var bufferPool = loop(11, function () {
     return []
   })
 
   function alloc (n) {
-    var step16 = n <= 1 << 28
-    var sz = step16 ? nextPow16(n) : nextPow8(n)
-    var bi = step16 ? log2(sz) >> 2 : log2(sz) / 3
-    var bin = (step16 ? bufferPool16 : bufferPool8)[bi]
+    var sz = nextPow8(n)
+    var bi = log2(sz) / 3
+    var bin = bufferPool[bi]
     if (bin.length > 0) {
       return bin.pop()
     }
@@ -60,9 +47,8 @@ function createPool () {
 
   function free (buf) {
     var sz = buf.byteLength
-    var step16 = sz <= 1 << 28
-    var bi = step16 ? log2(sz) >> 2 : log2(sz) / 3
-    var bin = (step16 ? bufferPool16 : bufferPool8)[bi]
+    var bi = log2(sz) / 3
+    var bin = bufferPool[bi]
     bin.push(buf)
   }
 

--- a/lib/util/pool.js
+++ b/lib/util/pool.js
@@ -8,6 +8,15 @@ var GL_INT = 5124
 var GL_UNSIGNED_INT = 5125
 var GL_FLOAT = 5126
 
+function nextPow8 (v) {
+  for (var i = 8; i <= (1 << 30); i *= 8) {
+    if (v <= i) {
+      return i
+    }
+  }
+  return 0
+}
+
 function nextPow16 (v) {
   for (var i = 16; i <= (1 << 28); i *= 16) {
     if (v <= i) {
@@ -31,13 +40,18 @@ function log2 (v) {
 }
 
 function createPool () {
-  var bufferPool = loop(8, function () {
+  var bufferPool16 = loop(8, function () {
+    return []
+  })
+  var bufferPool8 = loop(11, function () {
     return []
   })
 
   function alloc (n) {
-    var sz = nextPow16(n)
-    var bin = bufferPool[log2(sz) >> 2]
+    var step16 = n <= 1 << 28
+    var sz = step16 ? nextPow16(n) : nextPow8(n)
+    var bi = step16 ? log2(sz) >> 2 : log2(sz) / 3
+    var bin = (step16 ? bufferPool16 : bufferPool8)[bi]
     if (bin.length > 0) {
       return bin.pop()
     }
@@ -45,7 +59,11 @@ function createPool () {
   }
 
   function free (buf) {
-    bufferPool[log2(buf.byteLength) >> 2].push(buf)
+    var sz = buf.byteLength
+    var step16 = sz <= 1 << 28
+    var bi = step16 ? log2(sz) >> 2 : log2(sz) / 3
+    var bin = (step16 ? bufferPool16 : bufferPool8)[bi]
+    bin.push(buf)
   }
 
   function allocType (type, n) {

--- a/test/framebuffer-resize.js
+++ b/test/framebuffer-resize.js
@@ -45,6 +45,7 @@ tape('framebuffer resizing', function (t) {
   }
 
   var fbo = regl.framebuffer(10, 10)
+  var maxSize = regl.limits.maxRenderbufferSize
 
   t.equals(fbo.resize(10), fbo, 'resizing to same size does nothing')
   checkFBO(fbo, {width: 10, height: 10})
@@ -54,6 +55,9 @@ tape('framebuffer resizing', function (t) {
 
   t.equals(fbo.resize(8), fbo, 'resize returned the right thing')
   checkFBO(fbo, {width: 8, height: 8})
+
+  t.equals(fbo.resize(maxSize), fbo, 'resize returned the right thing')
+  checkFBO(fbo, {width: maxSize, height: maxSize})
 
   // reinitialize fbo
 


### PR DESCRIPTION
Fixes #498
Would be simpler to only use power of 8 size buffer pools, but I didn't want to change behavior for the most common use cases. 