### PR TITLE
Fix dampening in camera util

### DIFF
--- a/example/util/camera.js
+++ b/example/util/camera.js
@@ -49,7 +49,7 @@ function createCamera (regl, props) {
 
   function damp (x) {
     var xd = x * 0.9
-    if (xd < 0.1) {
+    if (Math.abs(xd) < 0.1) {
       return 0
     }
     return xd


### PR DESCRIPTION
Without using an absolute value, the dampening would only work for a positive x, setting the value to zero immediately for negative x. This fix makes it dampen correctly for negative numbers.