### PR TITLE
Support sRGB texture format

### DIFF
--- a/lib/texture.js
+++ b/lib/texture.js
@@ -492,7 +492,10 @@ module.exports = function createTextureSet (
         glenum === GL_LUMINANCE ||
         glenum === GL_LUMINANCE_ALPHA ||
         glenum === GL_DEPTH_COMPONENT ||
-        glenum === GL_DEPTH_STENCIL) {
+        glenum === GL_DEPTH_STENCIL ||
+        (extensions.ext_srgb && 
+                (glenum === GL_SRGB_EXT ||
+                 glenum === GL_SRGB_ALPHA_EXT))) {
       color[glenum] = glenum
     } else if (glenum === GL_RGB5_A1 || key.indexOf('rgba') >= 0) {
       color[glenum] = GL_RGBA


### PR DESCRIPTION
Without this change, even when texture options have `format == "srgb"`, it would use `GL_RGB` anyways.