### PR TITLE
Give attribute singular name by convention

### DIFF
--- a/API.md
+++ b/API.md
@@ -705,7 +705,7 @@ var command = regl({
 
   attributes: {
     // Attributes can be declared explicitly
-    normals: {
+    normal: {
       buffer: regl.buffer([
         // ...
       ]),


### PR DESCRIPTION
Shouldn't this read `normal`, to match `position` and `color` below?