### PR TITLE
Nested dynamic types

### DIFF
--- a/example/typescript/dynamic.ts
+++ b/example/typescript/dynamic.ts
@@ -4,8 +4,8 @@
   <p> This example shows how to pass props to draw commands </p>
 */
 
-import REGL = require("../../regl");
-const regl = REGL();
+import REGL = require('../../regl')
+const regl = REGL()
 
 interface Uniforms {
   angle: number;
@@ -39,12 +39,15 @@ const draw = regl<Uniforms, Attributes, Props>({
     }`,
 
   attributes: {
-    position: [-1, 0, 0, -1, 1, 1]
+    position: [
+      -1, 0,
+      0, -1,
+      1, 1]
   },
 
   uniforms: {
-    color: regl.prop<Props, "color">("color"),
-    angle: ({ tick }) => 0.01 * tick
+    color: regl.prop<Props, 'color'>('color'),
+    angle: ({tick}) => 0.01 * tick
   },
 
   depth: {
@@ -65,13 +68,14 @@ const draw = regl<Uniforms, Attributes, Props>({
       };
     }
   },
-  count: 3
-});
 
-regl.frame(({ tick }) => {
+  count: 3
+})
+
+regl.frame(({tick}) => {
   regl.clear({
     color: [0, 0, 0, 1]
-  });
+  })
 
   draw({
     color: [
@@ -80,5 +84,5 @@ regl.frame(({ tick }) => {
       Math.sin(0.02 * (0.3 * tick)),
       1
     ]
-  });
-});
+  })
+})

--- a/example/typescript/dynamic.ts
+++ b/example/typescript/dynamic.ts
@@ -4,8 +4,8 @@
   <p> This example shows how to pass props to draw commands </p>
 */
 
-import REGL = require('../../regl')
-const regl = REGL()
+import REGL = require("../../regl");
+const regl = REGL();
 
 interface Uniforms {
   angle: number;
@@ -39,28 +39,39 @@ const draw = regl<Uniforms, Attributes, Props>({
     }`,
 
   attributes: {
-    position: [
-      -1, 0,
-      0, -1,
-      1, 1]
+    position: [-1, 0, 0, -1, 1, 1]
   },
 
   uniforms: {
-    color: regl.prop<Props, 'color'>('color'),
-    angle: ({tick}) => 0.01 * tick
+    color: regl.prop<Props, "color">("color"),
+    angle: ({ tick }) => 0.01 * tick
   },
 
   depth: {
     enable: false
   },
 
+  scissor: {
+    enable: true,
+    box: ({ tick, viewportWidth, viewportHeight }) => {
+      const SCISSOR_TIME = 500;
+      const percent = (tick % SCISSOR_TIME) / SCISSOR_TIME;
+      const scaleFactor = (percent >= 0.5 ? 1 - percent : percent) * 2.0;
+      return {
+        x: (viewportWidth / 2) * scaleFactor,
+        y: (viewportHeight / 2) * scaleFactor,
+        width: viewportWidth - viewportWidth * scaleFactor,
+        height: viewportHeight - viewportHeight * scaleFactor
+      };
+    }
+  },
   count: 3
-})
+});
 
-regl.frame(({tick}) => {
+regl.frame(({ tick }) => {
   regl.clear({
     color: [0, 0, 0, 1]
-  })
+  });
 
   draw({
     color: [
@@ -69,5 +80,5 @@ regl.frame(({tick}) => {
       Math.sin(0.02 * (0.3 * tick)),
       1
     ]
-  })
-})
+  });
+});

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -352,6 +352,9 @@ declare namespace REGL {
     DynamicVariable<Type> |
     DynamicVariableFn<Type, Context, Props>;
 
+  type MaybeNestedDynamic<Type, Context extends REGL.DefaultContext, Props extends {}> =
+    { [K in keyof Type]: MaybeDynamic<Type[K], Context, Props> };
+
   interface ClearOptions {
     /**
      * RGBA values (range 0-1) to use when the color buffer is cleared. Initial value: [0, 0, 0, 0].
@@ -604,7 +607,7 @@ declare namespace REGL {
 
     /* Scissor */
 
-    scissor?: MaybeDynamic<REGL.ScissorOptions, ParentContext & OwnContext, Props>;
+    scissor?: MaybeNestedDynamic<REGL.ScissorOptions, ParentContext & OwnContext, Props>;
 
     /* Viewport */
 


### PR DESCRIPTION
Adds a new generic type `MaybeNestedDynamic` which can be used to type all child properties of a type to be `MaybeDynamic`. This is then applied to the `scissor` property to allow it to be properly typed for dynamic use.

This PR also updates the dynamic typescript example to exercise this case.