### PR TITLE
Fix types framebuffercube

### DIFF
--- a/dist/regl.d.ts
+++ b/dist/regl.d.ts
@@ -1515,7 +1515,7 @@ declare namespace REGL {
     resize(radius: number): REGL.FramebufferCube;
          
     /* Faces of the FramebufferCube */
-    faces?: [
+    faces: [
       REGL.Framebuffer,
       REGL.Framebuffer,
       REGL.Framebuffer,

--- a/dist/regl.d.ts
+++ b/dist/regl.d.ts
@@ -1513,6 +1513,16 @@ declare namespace REGL {
 
     /* Resizes the FramebufferCube and all its attachments. */
     resize(radius: number): REGL.FramebufferCube;
+         
+    /* Faces of the FramebufferCube */
+    faces?: [
+      REGL.Framebuffer,
+      REGL.Framebuffer,
+      REGL.Framebuffer,
+      REGL.Framebuffer,
+      REGL.Framebuffer
+    ]
+
   }
 
   interface FramebufferCubeOptions {

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -1515,7 +1515,7 @@ declare namespace REGL {
     resize(radius: number): REGL.FramebufferCube;
          
     /* Faces of the FramebufferCube */
-    faces?: [
+    faces: [
       REGL.Framebuffer,
       REGL.Framebuffer,
       REGL.Framebuffer,

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -1513,6 +1513,15 @@ declare namespace REGL {
 
     /* Resizes the FramebufferCube and all its attachments. */
     resize(radius: number): REGL.FramebufferCube;
+         
+    /* Faces of the FramebufferCube */
+    faces?: [
+      REGL.Framebuffer,
+      REGL.Framebuffer,
+      REGL.Framebuffer,
+      REGL.Framebuffer,
+      REGL.Framebuffer
+    ]
   }
 
   interface FramebufferCubeOptions {


### PR DESCRIPTION
Fix types in FramebufferCube.

This fix the error `Property 'faces' does not exist on type 'FramebufferCube'` when try to port to Typescript the example `point-light-shadow`. See [Line 142](https://github.com/regl-project/regl/blob/e36bef9379b63918514c7fa7d2e5abf413634f56/example/point-light-shadow.js#L142).