### PR TITLE
Fix switching between const and non-const attributes

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2286,6 +2286,7 @@ module.exports = function reglCore (
           '}if(', CUTE_COMPONENTS.map(function (c, i) {
             return BINDING + '.' + c + '!==' + CONST_COMPONENTS[i]
           }).join('||'), '){',
+          BINDING, '.buffer=null;',
           GL, '.vertexAttrib4f(', LOCATION, ',', CONST_COMPONENTS, ');',
           CUTE_COMPONENTS.map(function (c, i) {
             return BINDING + '.' + c + '=' + CONST_COMPONENTS[i] + ';'

--- a/test/attribute-constants.js
+++ b/test/attribute-constants.js
@@ -15,7 +15,7 @@ tape('attribute constants', function (t) {
   createContext.refreshCanvas();
 
   var gl = createContext(2, 2)
-  var regl = createREGL({gl: gl})
+  var regl = createREGL(gl)
 
   var vert = [
     'precision highp float;',

--- a/test/attribute-constants.js
+++ b/test/attribute-constants.js
@@ -12,7 +12,7 @@ tape('attribute constants', function (t) {
   //
   // A more robust long-term solution is perhaps to have regl query the available extensions and
   // register them as available even if you did not ask for them.
-  createContext.refreshCanvas();
+  createContext.refreshCanvas()
 
   var gl = createContext(2, 2)
   var regl = createREGL(gl)
@@ -336,8 +336,8 @@ tape('attribute constants', function (t) {
     t.equal(pixels[0], 0)
     t.equal(pixels[4], 255)
 
-    t.end();
-  });
+    t.end()
+  })
 
   regl.destroy()
   createContext.destroy(gl)

--- a/test/attribute-constants.js
+++ b/test/attribute-constants.js
@@ -4,8 +4,18 @@ var createContext = require('./util/create-context')
 var createREGL = require('../regl')
 
 tape('attribute constants', function (t) {
+  // This test does not work unless we either perform a complete refresh of the canvas element or
+  // enable the ANGLE_instanced_arrays extension. That should not need to be the case, but since
+  // earlier tests use the ANGLE_instanced_arrays extension and since this test does not, the
+  // canvas ends up polluted and managing divisors is necessary even though this particular regl
+  // context does not know about the extension.
+  //
+  // A more robust long-term solution is perhaps to have regl query the available extensions and
+  // register them as available even if you did not ask for them.
+  createContext.refreshCanvas();
+
   var gl = createContext(2, 2)
-  var regl = createREGL(gl)
+  var regl = createREGL({gl: gl})
 
   var vert = [
     'precision highp float;',
@@ -275,6 +285,59 @@ tape('attribute constants', function (t) {
       })
     })
   })
+
+  t.test('attributes switched between const and non-const', function (t) {
+    var drawForSwitching = regl({
+      frag: [
+        'void main() {',
+        '  gl_FragColor = vec4(1,0,0,0);',
+        '}'
+      ].join('\n'),
+      vert: [
+        'precision highp float;',
+        'attribute vec2 position;',
+        'attribute float isActive;',
+        'void main() {',
+        ' if (isActive == 0.) return;',
+        ' gl_PointSize = 1.;',
+        ' gl_Position = vec4(position, 0, 1);',
+        '}'
+      ].join('\n'),
+      attributes: {
+        position: [
+          [-0.5, -0.5],
+          [0.5, -0.5]
+        ],
+        isActive: regl.prop('isActive')
+      },
+      depth: {enable: false},
+      count: 2,
+      primitive: 'points'
+    })
+
+    regl.clear({color: [0, 0, 0, 0]})
+    drawForSwitching({isActive: [0, 1]})
+
+    var pixels = regl.read()
+    t.equal(pixels[0], 0)
+    t.equal(pixels[4], 255)
+
+    regl.clear({color: [0, 0, 0, 0]})
+    drawForSwitching({isActive: {constant: [1]}})
+
+    pixels = regl.read()
+    t.equal(pixels[0], 255)
+    t.equal(pixels[4], 255)
+
+    regl.clear({color: [0, 0, 0, 0]})
+    drawForSwitching({isActive: [0, 1]})
+
+    pixels = regl.read()
+    t.equal(pixels[0], 0)
+    t.equal(pixels[4], 255)
+
+    t.end();
+  });
 
   regl.destroy()
   createContext.destroy(gl)

--- a/test/util/create-context.js
+++ b/test/util/create-context.js
@@ -1,23 +1,33 @@
 if (typeof document !== 'undefined') {
-  var canvas = document.createElement('canvas')
-  var opts = {
-    antialias: false,
-    stencil: true,
-    preserveDrawingBuffer: true
+  var canvas, opts, context
+
+  function refreshCanvas () {
+    if (canvas) canvas.remove();
+
+    canvas = document.createElement('canvas')
+    opts = {
+      antialias: false,
+      stencil: true,
+      preserveDrawingBuffer: true
+    }
+    context = canvas.getContext('webgl', opts) || canvas.getContext('experimental-webgl', opts)
+    canvas.style.position = 'fixed'
+    canvas.style.top = '0'
+    canvas.style.right = '0'
+    canvas.style.width = '256px'
+    canvas.style.height = '256px'
+    document.body.appendChild(canvas)
   }
-  var context = canvas.getContext('webgl', opts) || canvas.getContext('experimental-webgl', opts)
-  canvas.style.position = 'fixed'
-  canvas.style.top = '0'
-  canvas.style.right = '0'
-  canvas.style.width = '256px'
-  canvas.style.height = '256px'
-  document.body.appendChild(canvas)
+
+  refreshCanvas()
 
   module.exports = function (width, height) {
     canvas.width = width
     canvas.height = height
     return context
   }
+
+  module.exports.refreshCanvas = refreshCanvas
 
   module.exports.resize = function (gl, w, h) {
     canvas.width = w

--- a/test/util/create-context.js
+++ b/test/util/create-context.js
@@ -1,8 +1,8 @@
 if (typeof document !== 'undefined') {
   var canvas, opts, context
 
-  function refreshCanvas () {
-    if (canvas) canvas.remove();
+  var refreshCanvas = function () {
+    if (canvas) canvas.remove()
 
     canvas = document.createElement('canvas')
     opts = {


### PR DESCRIPTION
This PR fixes switching between constant and non-constant attributes. See: #474. At the end of the day, the simple problem was that constant attributes set some properties on the `BINDING` via

```js
          CUTE_COMPONENTS.map(function (c, i) { 
            return BINDING + '.' + c + '=' + CONST_COMPONENTS[i] + ';'
          }).join(''),
```

but do not actively *unset* `buffer`. As a result, the the next call to a buffer attribute does not notice that buffer attributes were previously disabled and now must be enabled. The solution was to simply set `BINDING.buffer=null` when using constant attributes.

The other half of the debugging was working around a strange instanced arrays interaction detailed in #544.

Sorry it took so long to get to to the bottom of this, but thanks @dy for providing such a debuggable test case!