### PR TITLE
fix texImage2D with depth texture

### DIFF
--- a/lib/texture.js
+++ b/lib/texture.js
@@ -843,7 +843,11 @@ module.exports = function createTextureSet (
     } else {
       var nullData = !data
       if (nullData) {
-        data = pool.zero.allocType(type, width * height * channels)
+        if (format !== GL_DEPTH_COMPONENT) {
+          data = pool.zero.allocType(type, width * height * channels)
+        } else {
+          data = null
+        }
       }
 
       gl.texImage2D(target, miplevel, format, width, height, 0, format, type, data)
@@ -1343,7 +1347,9 @@ module.exports = function createTextureSet (
         var _w = w >> i
         var _h = h >> i
         if (!_w || !_h) break
-        data = pool.zero.allocType(type, _w * _h * channels)
+        if (texture.format !== GL_DEPTH_COMPONENT) {
+          data = pool.zero.allocType(type, _w * _h * channels)
+        }
         gl.texImage2D(
           GL_TEXTURE_2D,
           i,

--- a/test/texture2d.js
+++ b/test/texture2d.js
@@ -8,7 +8,7 @@ tape('texture 2d', function (t) {
   var regl = createREGL(
     {
       gl: gl,
-      optionalExtensions: ['webgl_compressed_texture_s3tc', 'ext_texture_filter_anisotropic', 'oes_texture_float', 'oes_texture_half_float']
+      optionalExtensions: ['webgl_compressed_texture_s3tc', 'ext_texture_filter_anisotropic', 'oes_texture_float', 'oes_texture_half_float', 'webgl_depth_texture']
     })
 
   var renderTexture = regl({
@@ -1088,6 +1088,25 @@ tape('texture 2d', function (t) {
       mag: 'nearest'
     },
     'magwrap4')
+
+  var depthTexture = regl.texture({
+    format: 'depth',
+    type: 'uint16',
+    width: 2,
+    height: 2
+  })
+  checkProperties(
+    depthTexture,
+    {
+      format: 'depth',
+      type: 'uint16',
+      minFilter: gl.LINEAR_MIPMAP_LINEAR,
+      magFilter: gl.LINEAR,
+      width: 2,
+      height: 2
+    },
+    'depthTexture')
+  depthTexture.resize(4, 4);
 
   if (typeof document !== 'undefined') {
     runDOMTests()

--- a/test/texture2d.js
+++ b/test/texture2d.js
@@ -1089,24 +1089,21 @@ tape('texture 2d', function (t) {
     },
     'magwrap4')
 
+  checkShouldNotThrow(
+    {
+      format: 'depth',
+      type: 'uint16',
+      width: 2,
+      height: 2
+    },
+    'depthTexture')
   var depthTexture = regl.texture({
     format: 'depth',
     type: 'uint16',
     width: 2,
     height: 2
   })
-  checkProperties(
-    depthTexture,
-    {
-      format: 'depth',
-      type: 'uint16',
-      minFilter: gl.LINEAR_MIPMAP_LINEAR,
-      magFilter: gl.LINEAR,
-      width: 2,
-      height: 2
-    },
-    'depthTexture')
-  depthTexture.resize(4, 4);
+  depthTexture.resize(4, 4)
 
   if (typeof document !== 'undefined') {
     runDOMTests()


### PR DESCRIPTION
This PR is a fix to depth texture's initialization, e.g:
```js
regl.texture({
  format: 'depth',
  type: 'uint32'
})
```

When calling `gl.texImage2D` with depth texture, the last param `data` can't be an allocated array, otherwise the following webgl error will be thrown out:
`WebGL: INVALID_OPERATION: texImage2D: format can not be set, only rendered to`

```js
//with depth texture, data must be null
gl.texImage2D(target, miplevel, format, width, height, 0, format, type, data)
```

[reproduction](https://codepen.io/fuzhenn-the-decoder/pen/vYBvEwv): The webgl error will be printed out in console.