### PR TITLE
Add cemsim.com (EM sim) to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The following is an incomplete list of projects using regl:
 * [CitiBike Commute](https://tbaldw.in/citibike-trips)
 * [Audiofabric](https://tbaldw.in/audiofabric)
 * [All the Buildings in Manhattan](https://tbaldw.in/nyc-buildings)
+* [Interactive Electromagnetic Field Simulation](https://cemsim.com)
 
 If you have a project using regl that isn't on this list that you would like to see added, [please send us a pull request!](https://github.com/regl-project/regl/edit/gh-pages/README.md)
 


### PR DESCRIPTION
I recently switched my web-based interactive electromagnetic field simulation to use regl which was very easy to do (took me only a day). Thank you for the great library!

The live version can be found here: https://cemsim.com
And the repository here: https://github.com/RobinKa/maxwell-simulation