### PR TITLE
Fix to continue support es5

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -98,7 +98,7 @@ module.exports = function wrapAttributeState (
       vao.bindAttrs()
     } else {
       var exti = extInstanced()
-      for (let i = 0; i < attributeBindings.length; ++i) {
+      for (var i = 0; i < attributeBindings.length; ++i) {
         var binding = attributeBindings[i]
         if (binding.buffer) {
           gl.enableVertexAttribArray(i)
@@ -116,7 +116,7 @@ module.exports = function wrapAttributeState (
   }
 
   function destroyVAOEXT (vao) {
-    values(vaoSet).forEach((vao) => {
+    values(vaoSet).forEach(function (vao) {
       vao.destroy()
     })
   }

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -115,7 +115,7 @@ module.exports = function wrapAttributeState (
     state.currentVAO = vao
   }
 
-  function destroyVAOEXT (vao) {
+  function destroyVAOEXT () {
     values(vaoSet).forEach(function (vao) {
       vao.destroy()
     })


### PR DESCRIPTION
@rreusser FYI - on `plotly.js` repo we had problem upgrading because of those es6 keywords.