### PR TITLE
Fix a non-standard default value for premultiplied alpha

### DIFF
--- a/lib/webgl.js
+++ b/lib/webgl.js
@@ -197,7 +197,7 @@ module.exports = function parseArgs (args_) {
       onDestroy = result.onDestroy
     }
     // workaround for chromium bug, premultiplied alpha value is platform dependent
-    contextAttributes.premultipliedAlpha = contextAttributes.premultipliedAlpha || false
+    contextAttributes.premultipliedAlpha = contextAttributes.premultipliedAlpha || true
     gl = createContext(canvas, contextAttributes)
   }
 


### PR DESCRIPTION
See #565 

It seems to be the case that a browser was behaving buggily with no premultipliedAlpha value specified so that regl elects to fill it in. However, the false value supplied by regl seems to conflict with the preferred value in [WebGLContextAttributes which appears to be true](https://www.khronos.org/registry/webgl/specs/1.0/#5.2):

```
dictionary WebGLContextAttributes {
    ...
    GLboolean premultipliedAlpha = true;
};
```

If merged, this will be published as a minor version under 1.6.0.

/cc @mikolalysenko @dy @archmoj 