### PR TITLE
remove unnecessary vertexAttribDivisorANGLE

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -103,7 +103,7 @@ module.exports = function wrapAttributeState (
         if (binding.buffer) {
           gl.enableVertexAttribArray(i)
           gl.vertexAttribPointer(i, binding.size, binding.type, binding.normalized, binding.stride, binding.offfset)
-          if (exti) {
+          if (exti && binding.divisor) {
             exti.vertexAttribDivisorANGLE(i, binding.divisor)
           }
         } else {
@@ -143,7 +143,7 @@ module.exports = function wrapAttributeState (
         gl.enableVertexAttribArray(i)
         gl.bindBuffer(GL_ARRAY_BUFFER, attr.buffer.buffer)
         gl.vertexAttribPointer(i, attr.size, attr.type, attr.normalized, attr.stride, attr.offset)
-        if (exti) {
+        if (exti && attr.divisor) {
           exti.vertexAttribDivisorANGLE(i, attr.divisor)
         }
       } else {


### PR DESCRIPTION
When attribute's divisor is 0 (mostly), it doesn't need to call vertexAttribDivisorANGLE