### PR TITLE
some vao fixes

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -210,8 +210,14 @@ module.exports = function wrapAttributeState (
           var buf
           if (vao.buffers[i]) {
             buf = vao.buffers[i]
-            buf.subdata(data)
-          } else {
+            if (isTypedArray(data) && buf._buffer.byteLength >= data.byteLength) {
+              buf.subdata(data)
+            } else {
+              buf.destroy()
+              vao.buffers[i] = null
+            }
+          }
+          if (!vao.buffers[i]) {
             buf = vao.buffers[i] = bufferState.create(spec, GL_ARRAY_BUFFER, false, true)
           }
           rec.buffer = bufferState.getBuffer(buf)

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -167,12 +167,6 @@ module.exports = function wrapAttributeState (
 
   REGLVAO.prototype.destroy = function () {
     if (this.vao) {
-      for (var j = 0; j < this.vao.buffers.length; ++j) {
-        if (this.vao.buffers[j]) {
-          this.vao.buffers[j].destroy()
-        }
-      }
-      this.vao.buffers.length = 0
       var extension = extVAO()
       if (this === state.currentVAO) {
         state.currentVAO = null
@@ -211,11 +205,12 @@ module.exports = function wrapAttributeState (
       for (var i = 0; i < attributes.length; ++i) {
         var spec = attributes[i]
         var rec = nattributes[i] = new AttributeRecord()
-        if (Array.isArray(spec) || isTypedArray(spec) || isNDArrayLike(spec)) {
+        var data = spec.data || spec
+        if (Array.isArray(data) || isTypedArray(data) || isNDArrayLike(data)) {
           var buf
           if (vao.buffers[i]) {
             buf = vao.buffers[i]
-            buf.subdata(spec)
+            buf.subdata(data)
           } else {
             buf = vao.buffers[i] = bufferState.create(spec, GL_ARRAY_BUFFER, false, true)
           }
@@ -282,6 +277,12 @@ module.exports = function wrapAttributeState (
     }
 
     updateVAO.destroy = function () {
+      for (var j = 0; j < vao.buffers.length; ++j) {
+        if (vao.buffers[j]) {
+          vao.buffers[j].destroy()
+        }
+      }
+      vao.buffers.length = 0
       vao.destroy()
     }
 

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -103,7 +103,7 @@ module.exports = function wrapAttributeState (
         if (binding.buffer) {
           gl.enableVertexAttribArray(i)
           gl.vertexAttribPointer(i, binding.size, binding.type, binding.normalized, binding.stride, binding.offfset)
-          if (exti) {
+          if (exti && binding.divisor) {
             exti.vertexAttribDivisorANGLE(i, binding.divisor)
           }
         } else {
@@ -143,7 +143,7 @@ module.exports = function wrapAttributeState (
         gl.enableVertexAttribArray(i)
         gl.bindBuffer(GL_ARRAY_BUFFER, attr.buffer.buffer)
         gl.vertexAttribPointer(i, attr.size, attr.type, attr.normalized, attr.stride, attr.offset)
-        if (exti) {
+        if (exti && attr.divisor) {
           exti.vertexAttribDivisorANGLE(i, attr.divisor)
         }
       } else {
@@ -167,6 +167,12 @@ module.exports = function wrapAttributeState (
 
   REGLVAO.prototype.destroy = function () {
     if (this.vao) {
+      for (var j = 0; j < this.vao.buffers.length; ++j) {
+        if (this.vao.buffers[j]) {
+          this.vao.buffers[j].destroy()
+        }
+      }
+      this.vao.buffers.length = 0
       var extension = extVAO()
       if (this === state.currentVAO) {
         state.currentVAO = null
@@ -199,18 +205,20 @@ module.exports = function wrapAttributeState (
       check(attributes.length < NUM_ATTRIBUTES, 'too many attributes')
       check(attributes.length > 0, 'must specify at least one attribute')
 
-      for (var j = 0; j < vao.buffers.length; ++j) {
-        vao.buffers[j].destroy()
-      }
-      vao.buffers.length = 0
-
+      var bufUpdated = {}
       var nattributes = vao.attributes
       nattributes.length = attributes.length
       for (var i = 0; i < attributes.length; ++i) {
         var spec = attributes[i]
         var rec = nattributes[i] = new AttributeRecord()
         if (Array.isArray(spec) || isTypedArray(spec) || isNDArrayLike(spec)) {
-          var buf = bufferState.create(spec, GL_ARRAY_BUFFER, false, true)
+          var buf
+          if (vao.buffers[i]) {
+            buf = vao.buffers[i]
+            buf.subdata(spec)
+          } else {
+            buf = vao.buffers[i] = bufferState.create(spec, GL_ARRAY_BUFFER, false, true)
+          }
           rec.buffer = bufferState.getBuffer(buf)
           rec.size = rec.buffer.dimension | 0
           rec.normalized = false
@@ -219,7 +227,7 @@ module.exports = function wrapAttributeState (
           rec.stride = 0
           rec.divisor = 0
           rec.state = 1
-          vao.buffers.push(buf)
+          bufUpdated[i] = 1
         } else if (bufferState.getBuffer(spec)) {
           rec.buffer = bufferState.getBuffer(spec)
           rec.size = rec.buffer.dimension | 0
@@ -258,6 +266,14 @@ module.exports = function wrapAttributeState (
           rec.state = 2
         } else {
           check(false, 'invalid attribute spec for location ' + i)
+        }
+      }
+
+      // retire unused buffers
+      for (var j = 0; j < vao.buffers.length; ++j) {
+        if (!bufUpdated[j] && vao.buffers[j]) {
+          vao.buffers[j].destroy()
+          vao.buffers[j] = null
         }
       }
 


### PR DESCRIPTION
Includes the following fixes and improvements:
* destroy vao.buffers in `vao.destroy()`
* not call `vertexAttribDivisorANGLE` if divisor is 0
* when updating vao, call `buffer.subdata` instead of creating a new buffer every time
* add support of data object when creating vao:
```js
regl.vao([
  // data object to support in this PR
  { data: new Float32Array(8), usage: 'dynamic' },
  // now we only support array
  Float32Array(32)
])
```