### PR TITLE
Add support for prop vectors in uniforms and context

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2073,7 +2073,7 @@ module.exports = function reglCore (
     Object.keys(context).forEach(function (name) {
       scope.save(CONTEXT, '.' + name)
       var defn = context[name]
-      var value = defn.append(env, scope);
+      var value = defn.append(env, scope)
       if (Array.isArray(value)) {
         contextEnter(CONTEXT, '.', name, '=[', value.join(), '];')
       } else {

--- a/lib/core.js
+++ b/lib/core.js
@@ -23,6 +23,8 @@ var DYN_PROP = 1
 var DYN_CONTEXT = 2
 var DYN_STATE = 3
 var DYN_THUNK = 4
+var DYN_CONSTANT = 5
+var DYN_ARRAY = 6
 
 var S_DITHER = 'dither'
 var S_BLEND_ENABLE = 'blend.enable'
@@ -266,6 +268,44 @@ function createDynamicDecl (dyn, append) {
       data.thisDep,
       data.contextDep,
       data.propDep,
+      append)
+  } else if (type === DYN_CONSTANT) {
+    return new Declaration(
+      false,
+      false,
+      false,
+      append)
+  } else if (type === DYN_ARRAY) {
+    var thisDep = false
+    var contextDep = false
+    var propDep = false
+    for (var i = 0; i < dyn.data.length; ++i) {
+      var subDyn = dyn.data[i]
+      if (subDyn.type === DYN_PROP) {
+        propDep = true
+      } else if (subDyn.type === DYN_CONTEXT) {
+        contextDep = true
+      } else if (subDyn.type === DYN_STATE) {
+        thisDep = true
+      } else if (subDyn.type === DYN_FUNC) {
+        thisDep = true
+        var subArgs = subDyn.data
+        if (subArgs >= 1) {
+          contextDep = true
+        }
+        if (subArgs >= 2) {
+          propDep = true
+        }
+      } else if (subDyn.type === DYN_THUNK) {
+        thisDep = thisDep || subDyn.data.thisDep
+        contextDep = contextDep || subDyn.data.contextDep
+        propDep = propDep || subDyn.data.propDep
+      }
+    }
+    return new Declaration(
+      thisDep,
+      contextDep,
+      propDep,
       append)
   } else {
     return new Declaration(
@@ -525,6 +565,12 @@ module.exports = function reglCore (
         case DYN_THUNK:
           x.data.append(env, block)
           return x.data.ref
+        case DYN_CONSTANT:
+          return x.data.toString()
+        case DYN_ARRAY:
+          return x.data.map(function (y) {
+            return env.invoke(block, y)
+          })
       }
     }
 
@@ -2027,7 +2073,12 @@ module.exports = function reglCore (
     Object.keys(context).forEach(function (name) {
       scope.save(CONTEXT, '.' + name)
       var defn = context[name]
-      contextEnter(CONTEXT, '.', name, '=', defn.append(env, scope), ';')
+      var value = defn.append(env, scope);
+      if (Array.isArray(value)) {
+        contextEnter(CONTEXT, '.', name, '=[', value.join(), '];')
+      } else {
+        contextEnter(CONTEXT, '.', name, '=', value, ';')
+      }
     })
 
     scope(contextEnter)
@@ -2557,11 +2608,13 @@ module.exports = function reglCore (
       }
 
       if (type === GL_SAMPLER_2D) {
+        check(!Array.isArray(VALUE), 'must specify a scalar prop for textures')
         scope(
           'if(', VALUE, '&&', VALUE, '._reglType==="framebuffer"){',
           VALUE, '=', VALUE, '.color[0];',
           '}')
       } else if (type === GL_SAMPLER_CUBE) {
+        check(!Array.isArray(VALUE), 'must specify a scalar prop for cube maps')
         scope(
           'if(', VALUE, '&&', VALUE, '._reglType==="framebufferCube"){',
           VALUE, '=', VALUE, '.color[0];',
@@ -2570,25 +2623,31 @@ module.exports = function reglCore (
 
       // perform type validation
       check.optional(function () {
-        function check (pred, message) {
+        function emitCheck (pred, message) {
           env.assert(scope, pred,
             'bad data or missing for uniform "' + name + '".  ' + message)
         }
 
         function checkType (type) {
-          check(
+          check(!Array.isArray(VALUE), 'must not specify an array type for uniform')
+          emitCheck(
             'typeof ' + VALUE + '==="' + type + '"',
             'invalid type, expected ' + type)
         }
 
         function checkVector (n, type) {
-          check(
-            shared.isArrayLike + '(' + VALUE + ')&&' + VALUE + '.length===' + n,
-            'invalid vector, should have length ' + n, env.commandStr)
+          if (Array.isArray(VALUE)) {
+            check(VALUE.length === n, 'must have length ' + n)
+          } else {
+            emitCheck(
+              shared.isArrayLike + '(' + VALUE + ')&&' + VALUE + '.length===' + n,
+              'invalid vector, should have length ' + n, env.commandStr)
+          }
         }
 
         function checkTexture (target) {
-          check(
+          check(!Array.isArray(VALUE), 'must not specify a value type')
+          emitCheck(
             'typeof ' + VALUE + '==="function"&&' +
             VALUE + '._reglType==="texture' +
             (target === GL_TEXTURE_2D ? '2d' : 'Cube') + '"',
@@ -2718,16 +2777,25 @@ module.exports = function reglCore (
       if (infix.charAt(0) === 'M') {
         var matSize = Math.pow(type - GL_FLOAT_MAT2 + 2, 2)
         var STORAGE = env.global.def('new Float32Array(', matSize, ')')
-        scope(
-          'false,(Array.isArray(', VALUE, ')||', VALUE, ' instanceof Float32Array)?', VALUE, ':(',
-          loop(matSize, function (i) {
-            return STORAGE + '[' + i + ']=' + VALUE + '[' + i + ']'
-          }), ',', STORAGE, ')')
+        if (Array.isArray(VALUE)) {
+          scope(
+            'false,(',
+            loop(matSize, function (i) {
+              return STORAGE + '[' + i + ']=' + VALUE[i]
+            }), ',', STORAGE, ')')
+        } else {
+          scope(
+            'false,(Array.isArray(', VALUE, ')||', VALUE, ' instanceof Float32Array)?', VALUE, ':(',
+            loop(matSize, function (i) {
+              return STORAGE + '[' + i + ']=' + VALUE + '[' + i + ']'
+            }), ',', STORAGE, ')')
+        }
       } else if (unroll > 1) {
         scope(loop(unroll, function (i) {
-          return VALUE + '[' + i + ']'
+          return Array.isArray(VALUE) ? VALUE[i] : VALUE + '[' + i + ']'
         }))
       } else {
+        check(!Array.isArray(VALUE), 'uniform value must not be an array')
         scope(VALUE)
       }
       scope(');')
@@ -3218,10 +3286,14 @@ module.exports = function reglCore (
       })
 
     Object.keys(args.uniforms).forEach(function (opt) {
+      var value = args.uniforms[opt].append(env, scope)
+      if (Array.isArray(value)) {
+        value = '[' + value.join() + ']'
+      }
       scope.set(
         shared.uniforms,
         '[' + stringStore.id(opt) + ']',
-        args.uniforms[opt].append(env, scope))
+        value)
     })
 
     Object.keys(args.attributes).forEach(function (name) {

--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -1,6 +1,10 @@
+const check = require("./util/check")
+
 var VARIABLE_COUNTER = 0
 
 var DYN_FUNC = 0
+var DYN_CONSTANT = 5
+var DYN_ARRAY = 6
 
 function DynamicVariable (type, data) {
   this.id = (VARIABLE_COUNTER++)
@@ -56,15 +60,20 @@ function defineDynamic (type, data) {
 }
 
 function isDynamic (x) {
-  return (typeof x === 'function' && !x._reglType) ||
-         x instanceof DynamicVariable
+  return (typeof x === 'function' && !x._reglType) || (x instanceof DynamicVariable)
 }
 
 function unbox (x, path) {
   if (typeof x === 'function') {
     return new DynamicVariable(DYN_FUNC, x)
+  } else if (typeof x === 'number' || typeof x === 'boolean') {
+    return new DynamicVariable(DYN_CONSTANT, x)
+  } else if (Array.isArray(x)) {
+    return new DynamicVariable(DYN_ARRAY, x.map((y, i) => unbox(y, path + '[' + i + ']')))
+  } else if (x instanceof DynamicVariable) {
+    return x
   }
-  return x
+  check(false, 'invalid option type in uniform ' + path)
 }
 
 module.exports = {

--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -1,4 +1,4 @@
-var check = require('./util/check');
+var check = require('./util/check')
 
 var VARIABLE_COUNTER = 0
 

--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -1,4 +1,4 @@
-const check = require("./util/check")
+var check = require('./util/check');
 
 var VARIABLE_COUNTER = 0
 

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -659,7 +659,7 @@ declare namespace REGL {
     Context extends REGL.DefaultContext,
     Props extends {}
   > = {
-    [Key in keyof Uniforms]: MaybeDynamic<Uniforms[Key], Context, Props>;
+    [Key in keyof Uniforms]: MaybeDynamic<Uniforms[Key], Context, Props>|MaybeDynamic<Uniforms[Key], Context, Props>[];
   }
 
   type AttributeState =

--- a/test/uniforms.js
+++ b/test/uniforms.js
@@ -135,7 +135,49 @@ tape('uniforms', function (t) {
             data: input
           }
         }))
-      }
+      },
+      propArray: function (frag, vert, input) {
+        if (!Array.isArray(input)) {
+          return baseConstructors.constant(frag, vert, input)
+        } 
+        return regl(extend(commandDesc, {
+          vert: vert,
+          frag: frag,
+          uniforms: {
+            data: input.map((_, i) => regl.prop('data[' + i + ']')),
+          },
+        }))
+      },
+
+      propArrayMixed: function (frag, vert, input) {
+        if (!Array.isArray(input)) {
+          return baseConstructors.constant(frag, vert, input)
+        } 
+        console.log(input);
+        return regl(extend(commandDesc, {
+          vert: vert,
+          frag: frag,
+          uniforms: {
+            data: input.map((_, i) => i === 0 ? regl.prop('data[' + i + ']') : input[i]),
+          },
+        }))
+      },
+
+      contextArray: function (frag, vert, input) {
+        if (!Array.isArray(input)) {
+          return baseConstructors.constant(frag, vert, input)
+        }
+        return regl(extend(commandDesc, {
+          vert: vert,
+          frag: frag,
+          uniforms: {
+            data: input.map((_, i) => regl.context('data[' + i + ']'))
+          },
+          context: {
+            data: input.map((_, i) => regl.prop('data[' + i + ']')),
+          }
+        }))
+      },
     }
 
     var constructors = {}

--- a/test/uniforms.js
+++ b/test/uniforms.js
@@ -153,7 +153,6 @@ tape('uniforms', function (t) {
         if (!Array.isArray(input)) {
           return baseConstructors.constant(frag, vert, input)
         }
-        console.log(input);
         return regl(extend(commandDesc, {
           vert: vert,
           frag: frag,

--- a/test/uniforms.js
+++ b/test/uniforms.js
@@ -139,27 +139,27 @@ tape('uniforms', function (t) {
       propArray: function (frag, vert, input) {
         if (!Array.isArray(input)) {
           return baseConstructors.constant(frag, vert, input)
-        } 
+        }
         return regl(extend(commandDesc, {
           vert: vert,
           frag: frag,
           uniforms: {
-            data: input.map((_, i) => regl.prop('data[' + i + ']')),
-          },
+            data: input.map((_, i) => regl.prop('data[' + i + ']'))
+          }
         }))
       },
 
       propArrayMixed: function (frag, vert, input) {
         if (!Array.isArray(input)) {
           return baseConstructors.constant(frag, vert, input)
-        } 
+        }
         console.log(input);
         return regl(extend(commandDesc, {
           vert: vert,
           frag: frag,
           uniforms: {
-            data: input.map((_, i) => i === 0 ? regl.prop('data[' + i + ']') : input[i]),
-          },
+            data: input.map((_, i) => i === 0 ? regl.prop('data[' + i + ']') : input[i])
+          }
         }))
       },
 
@@ -174,10 +174,10 @@ tape('uniforms', function (t) {
             data: input.map((_, i) => regl.context('data[' + i + ']'))
           },
           context: {
-            data: input.map((_, i) => regl.prop('data[' + i + ']')),
+            data: input.map((_, i) => regl.prop('data[' + i + ']'))
           }
         }))
-      },
+      }
     }
 
     var constructors = {}


### PR DESCRIPTION
This PR adds support for prop vector uniforms.  It simplifies integrating with libraries that may not use array-like vector components.  For example, you can now write:

```javascript
regl({
   // ...
   uniform: {
      color: [ regl.prop('r'), regl.prop('g'), regl.prop('b'), regl.prop('a') ]
   },
})
```

Instead of:

```javascript
regl({
   // ...
   uniform: {
      color: (context, props) => [ props.r, props.g, props.b, props.a ],
   },
})
```

While this may seem more verbose, it allows you to avoid creating an extra array reference and thus reduce memory allocations.