### PR TITLE
Fix VAO elements

### DIFF
--- a/API.md
+++ b/API.md
@@ -1577,6 +1577,21 @@ var command = regl({
 })
 ```
 
+You can also bake the element state into a vao:
+
+
+```javascript
+// First we create the VAO object
+var vao = regl.vao({
+  attributes: [
+    [ [0, 1], [1, 0], [1, 1] ],
+  },
+
+  // if not specified, then default is no elements
+  elements: [[ 0, 1, 2 ]],
+])
+```
+
 **Relevant WebGL APIs**
 
 -   [`OES_vertex_array_object`](https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/)

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -3,9 +3,20 @@ var values = require('./util/values')
 var bufferTypes = require('./constants/dtypes.json')
 var isTypedArray = require('./util/is-typed-array')
 var isNDArrayLike = require('./util/is-ndarray')
+var primitives = require('./constants/primitives.json')
 
 var GL_FLOAT = 5126
 var GL_ARRAY_BUFFER = 34962
+var GL_ELEMENT_ARRAY_BUFFER = 34963
+
+var VAO_OPTIONS = [
+  'attributes',
+  'elements',
+  'offset',
+  'count',
+  'primitive',
+  'instances'
+]
 
 function AttributeRecord () {
   this.state = 0
@@ -29,7 +40,9 @@ module.exports = function wrapAttributeState (
   extensions,
   limits,
   stats,
-  bufferState) {
+  bufferState,
+  elementState,
+  drawState) {
   var NUM_ATTRIBUTES = limits.maxAttributes
   var attributeBindings = new Array(NUM_ATTRIBUTES)
   for (var i = 0; i < NUM_ATTRIBUTES; ++i) {
@@ -102,6 +115,7 @@ module.exports = function wrapAttributeState (
         var binding = attributeBindings[i]
         if (binding.buffer) {
           gl.enableVertexAttribArray(i)
+          binding.buffer.bind()
           gl.vertexAttribPointer(i, binding.size, binding.type, binding.normalized, binding.stride, binding.offfset)
           if (exti && binding.divisor) {
             exti.vertexAttribDivisorANGLE(i, binding.divisor)
@@ -110,6 +124,11 @@ module.exports = function wrapAttributeState (
           gl.disableVertexAttribArray(i)
           gl.vertexAttrib4f(i, binding.x, binding.y, binding.z, binding.w)
         }
+      }
+      if (drawState.elements) {
+        gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, drawState.elements.buffer.buffer)
+      } else {
+        gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, null)
       }
     }
     state.currentVAO = vao
@@ -124,6 +143,12 @@ module.exports = function wrapAttributeState (
   function REGLVAO () {
     this.id = ++vaoCount
     this.attributes = []
+    this.elements = null
+    this.ownsElements = false
+    this.count = 0
+    this.offset = 0
+    this.instances = -1
+    this.primitive = 4
     var extension = extVAO()
     if (extension) {
       this.vao = extension.createVertexArrayOES()
@@ -154,6 +179,11 @@ module.exports = function wrapAttributeState (
     for (var j = attributes.length; j < NUM_ATTRIBUTES; ++j) {
       gl.disableVertexAttribArray(j)
     }
+    if (this.elements) {
+      gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.elements.buffer.buffer)
+    } else {
+      gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, null)
+    }
   }
 
   REGLVAO.prototype.refresh = function () {
@@ -175,6 +205,11 @@ module.exports = function wrapAttributeState (
       extension.deleteVertexArrayOES(this.vao)
       this.vao = null
     }
+    if (this.ownsElements) {
+      this.elements.destroy()
+      this.elements = null
+      this.ownsElements = false
+    }
     if (vaoSet[this.id]) {
       delete vaoSet[this.id]
       stats.vaoCount -= 1
@@ -194,8 +229,80 @@ module.exports = function wrapAttributeState (
     var vao = new REGLVAO()
     stats.vaoCount += 1
 
-    function updateVAO (attributes) {
-      check(Array.isArray(attributes), 'arguments to vertex array constructor must be an array')
+    function updateVAO (options) {
+      var attributes
+      if (Array.isArray(options)) {
+        attributes = options
+        if (vao.elements && vao.ownsElements) {
+          vao.elements.destroy()
+        }
+        vao.elements = null
+        vao.ownsElements = false
+        vao.offset = 0
+        vao.count = 0
+        vao.instances = -1
+        vao.primitive = 4
+      } else {
+        check(typeof options === 'object', 'invalid arguments for create vao')
+        check('attributes' in options, 'must specify attributes for vao')
+        if (options.elements) {
+          var elements = options.elements
+          if (vao.ownsElements) {
+            if (typeof elements === 'function' && elements._reglType === 'elements') {
+              vao.elements.destroy()
+              vao.ownsElements = false
+            } else {
+              vao.elements(elements)
+              vao.ownsElements = false
+            }
+          } else if (typeof elements === 'function' && elements._reglType === 'elements') {
+            vao.elements = elements
+            vao.ownsElements = false
+          } else {
+            vao.elements = elementState.create(elements)
+            vao.ownsElements = true
+          }
+        } else {
+          vao.elements = null
+          vao.ownsElements = false
+        }
+        attributes = options.attributes
+
+        // set default vao
+        vao.offset = 0
+        vao.count = 0
+        vao.instances = -1
+        vao.primitive = 4
+
+        // copy element properties
+        if (vao.elements) {
+          vao.count = vao.elements._elements.vertCount
+          vao.primitive = vao.elements._elements.primType
+        }
+
+        if ('offset' in options) {
+          vao.offset = options.offset | 0
+        }
+        if ('count' in options) {
+          vao.count = options.count | 0
+        }
+        if ('instances' in options) {
+          vao.instances = options.instances | 0
+        }
+        if ('primitive' in options) {
+          check(options.primitive in primitives, 'bad primitive type: ' + options.primitive)
+          vao.primitive = primitives[options.primitive]
+        }
+
+        check.optional(() => {
+          var keys = Object.keys(options)
+          for (var i = 0; i < keys.length; ++i) {
+            check(VAO_OPTIONS.indexOf(keys[i]) < 0, 'invalid argument for vao: ' + keys[i])
+          }
+        })
+        check(Array.isArray(attributes), 'attributes must be an array')
+      }
+
       check(attributes.length < NUM_ATTRIBUTES, 'too many attributes')
       check(attributes.length > 0, 'must specify at least one attribute')
 
@@ -289,6 +396,13 @@ module.exports = function wrapAttributeState (
         }
       }
       vao.buffers.length = 0
+
+      if (vao.ownsElements) {
+        vao.elements.destroy()
+        vao.elements = null
+        vao.ownsElements = false
+      }
+
       vao.destroy()
     }
 

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -179,8 +179,9 @@ module.exports = function wrapAttributeState (
     for (var j = attributes.length; j < NUM_ATTRIBUTES; ++j) {
       gl.disableVertexAttribArray(j)
     }
-    if (this.elements) {
-      gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.elements.buffer.buffer)
+    var elements = elementState.getElements(this.elements)
+    if (elements) {
+      gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, elements.buffer.buffer)
     } else {
       gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, null)
     }
@@ -297,7 +298,7 @@ module.exports = function wrapAttributeState (
         check.optional(() => {
           var keys = Object.keys(options)
           for (var i = 0; i < keys.length; ++i) {
-            check(VAO_OPTIONS.indexOf(keys[i]) < 0, 'invalid argument for vao: ' + keys[i])
+            check(VAO_OPTIONS.indexOf(keys[i]) >= 0, 'invalid option for vao: "' + keys[i] + '" valid options are ' + VAO_OPTIONS)
           }
         })
         check(Array.isArray(attributes), 'attributes must be an array')

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -271,7 +271,7 @@ module.exports = function wrapAttributeState (
 
         // set default vao
         vao.offset = 0
-        vao.count = 0
+        vao.count = -1
         vao.instances = -1
         vao.primitive = 4
 

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -256,11 +256,11 @@ module.exports = function wrapAttributeState (
               vao.elements(elements)
               vao.ownsElements = false
             }
-          } else if (typeof elements === 'function' && elements._reglType === 'elements') {
-            vao.elements = elements
+          } else if (elementState.getElements(options.elements)) {
+            vao.elements = options.elements
             vao.ownsElements = false
           } else {
-            vao.elements = elementState.create(elements)
+            vao.elements = elementState.create(options.elements)
             vao.ownsElements = true
           }
         } else {

--- a/lib/core.js
+++ b/lib/core.js
@@ -348,6 +348,7 @@ module.exports = function reglCore (
 
   var extInstancing = extensions.angle_instanced_arrays
   var extDrawBuffers = extensions.webgl_draw_buffers
+  var extVertexArrays = extensions.oes_vertex_array_object
 
   // ===================================================
   // ===================================================
@@ -1035,6 +1036,14 @@ module.exports = function reglCore (
 
           return elements
         })
+      } else if (vaoActive) {
+        return new Declaration(
+          vao.thisDep,
+          vao.contextDep,
+          vao.propDep,
+          function (env, scope) {
+            return scope.def(env.shared.vao + '.currentVAO?' + env.shared.elements + '.getElements(' + env.shared.vao + '.currentVAO.elements):' + env.shared.draw + '.elements')
+          })
       }
       return null
     }
@@ -2908,26 +2917,27 @@ module.exports = function reglCore (
       var defn = drawOptions.elements
       var ELEMENTS
       var scope = outer
-      if (drawOptions.vaoActive) {
-        // use vao for elements, don't touch element binding state
-        return scope.def(shared.vao + '.currentVAO.elements')
-      }
       if (defn) {
         if ((defn.contextDep && args.contextDynamic) || defn.propDep) {
           scope = inner
         }
-        ELEMENTS = defn.append(env, scope)
-        scope(
-          'if(' + ELEMENTS + ')' +
-          GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);')
+        if (drawOptions.vaoActive) {
+          ELEMENTS = defn.append(env, scope)
+        } else {
+          ELEMENTS = defn.append(env, scope)
+          scope(
+            'if(' + ELEMENTS + ')' +
+            GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);')
+        }
       } else {
         ELEMENTS = scope.def()
         scope('if(', shared.vao, '.currentVAO){',
-          ELEMENTS, '=', shared.vao, '.currentVAO.elements',
+          ELEMENTS, '=', env.shared.elements + '.getElements(' + shared.vao, '.currentVAO.elements);',
+          (!extVertexArrays ? 'if(' + ELEMENTS + ')' + GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);' : ''),
           '}else{',
           ELEMENTS, '=', DRAW_STATE, '.', S_ELEMENTS, ';',
-          'if(' + ELEMENTS + ')' +
-          GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);}')
+          'if(', ELEMENTS, '){',
+          GL, '.bindBuffer(', GL_ELEMENT_ARRAY_BUFFER, ',', ELEMENTS, '.buffer.buffer);}}')
       }
       return ELEMENTS
     }

--- a/lib/core.js
+++ b/lib/core.js
@@ -938,6 +938,7 @@ module.exports = function reglCore (
 
     var staticDraw = {}
     var vaoActive = false
+    var vaoLive = false
 
     function parseVAO () {
       if (S_VAO in staticOptions) {
@@ -948,7 +949,8 @@ module.exports = function reglCore (
           vao = attributeState.createVAO(vao)
         }
 
-        vaoActive = !!vao
+        vaoActive = true
+        vaoLive = !!vao
         staticDraw.vao = vao
 
         return createStaticDecl(function (env) {
@@ -962,6 +964,7 @@ module.exports = function reglCore (
       } else if (S_VAO in dynamicOptions) {
         check(!staticOptions.elements && !dynamicOptions.elements, 'cannot specify elements with vao')
         vaoActive = true
+        vaoLive = true
         var dyn = dynamicOptions[S_VAO]
         return createDynamicDecl(dyn, function (env, scope) {
           var vaoRef = env.invoke(scope, dyn)
@@ -977,7 +980,7 @@ module.exports = function reglCore (
 
     function parseElements () {
       if (S_ELEMENTS in staticOptions) {
-        check(!vaoActive, 'must not specify vao and elements')
+        check(!vaoLive, 'must not specify vao and elements')
 
         var elements = staticOptions[S_ELEMENTS]
         staticDraw.elements = elements
@@ -1003,7 +1006,7 @@ module.exports = function reglCore (
         result.value = elements
         return result
       } else if (S_ELEMENTS in dynamicOptions) {
-        check(!vao, 'must not specify vao and elements')
+        check(!vaoLive, 'must not specify vao and elements')
         elementsActive = true
 
         var dyn = dynamicOptions[S_ELEMENTS]
@@ -1138,19 +1141,19 @@ module.exports = function reglCore (
           return result
         })
       } else if (isOffset) {
-        if (vaoActive) {
+        if (elementsActive) {
+          return createStaticDecl(function (env, scope) {
+            env.OFFSET = 0
+            return 0
+          })
+        } else if (vaoActive) {
           return new Declaration(
             vao.thisDep,
             vao.contextDep,
             vao.propDep,
             function (env, scope) {
-              return scope.def(env.shared.vao + '.currentVAO?' + env.shared.vao + '.currentVAO.offset:' + env.shared.draw + '.offset')
+              return scope.def(env.shared.vao + '.currentVAO?' + env.shared.vao + '.currentVAO.offset:0')
             })
-        } else if (elementsActive) {
-          return createStaticDecl(function (env, scope) {
-            env.OFFSET = 0
-            return 0
-          })
         }
       } else if (vaoActive) {
         return new Declaration(
@@ -2155,6 +2158,7 @@ module.exports = function reglCore (
       }
     }
     if (attribLocations) {
+      check(!draw.elementsActive, 'can not combine elements and vertex array objects. element binding state must be specified in vertex array object')
       result.useVAO = true
     } else {
       result.attributes = parseAttributes(attributes, env)
@@ -3003,7 +3007,7 @@ module.exports = function reglCore (
 
     var ELEMENT_TYPE = ELEMENTS + '.type'
 
-    var elementsStatic = drawOptions.elements && isStatic(drawOptions.elements)
+    var elementsStatic = drawOptions.elements && isStatic(drawOptions.elements) && !drawOptions.vaoActive
 
     function emitInstancing () {
       function drawElements () {

--- a/lib/core.js
+++ b/lib/core.js
@@ -1042,7 +1042,7 @@ module.exports = function reglCore (
           vao.contextDep,
           vao.propDep,
           function (env, scope) {
-            return scope.def(env.shared.vao + '.currentVAO?' + env.shared.elements + '.getElements(' + env.shared.vao + '.currentVAO.elements):' + env.shared.draw + '.elements')
+            return scope.def(env.shared.vao + '.currentVAO?' + env.shared.elements + '.getElements(' + env.shared.vao + '.currentVAO.elements):null')
           })
       }
       return null
@@ -1102,7 +1102,7 @@ module.exports = function reglCore (
           vao.contextDep,
           vao.propDep,
           function (env, scope) {
-            return scope.def(env.shared.vao + '.currentVAO?' + env.shared.vao + '.currentVAO.primitive:' + env.shared.draw + '.primitive')
+            return scope.def(env.shared.vao + '.currentVAO?' + env.shared.vao + '.currentVAO.primitive:' + GL_TRIANGLES)
           })
       }
       return null
@@ -1158,7 +1158,7 @@ module.exports = function reglCore (
           vao.contextDep,
           vao.propDep,
           function (env, scope) {
-            return scope.def(env.shared.vao + '.currentVAO?' + env.shared.vao + '.currentVAO.instances:' + env.shared.draw + '.instances')
+            return scope.def(env.shared.vao + '.currentVAO?' + env.shared.vao + '.currentVAO.instances:-1')
           })
       }
       return null
@@ -1246,7 +1246,7 @@ module.exports = function reglCore (
           vao.contextDep,
           vao.propDep,
           function (env, scope) {
-            return scope.def(env.shared.vao, '.currentVAO?', env.shared.vao, '.currentVAO.count:', env.shared.draw + '.count')
+            return scope.def(env.shared.vao, '.currentVAO?', env.shared.vao, '.currentVAO.count:-1')
           })
         return countVariable
       }

--- a/lib/core.js
+++ b/lib/core.js
@@ -932,15 +932,64 @@ module.exports = function reglCore (
     var staticOptions = options.static
     var dynamicOptions = options.dynamic
 
+    // TODO: should use VAO to get default values for offset properties
+    // should move vao parse into here and out of the old stuff
+
+    var staticDraw = {}
+    var vaoActive = false
+
+    function parseVAO () {
+      if (S_VAO in staticOptions) {
+        check(!staticOptions.elements && !dynamicOptions.elements, 'cannot specify elements with vao')
+
+        var vao = staticOptions[S_VAO]
+        if (vao !== null && attributeState.getVAO(vao) === null) {
+          vao = attributeState.createVAO(vao)
+        }
+
+        vaoActive = !!vao
+        staticDraw.vao = vao
+
+        return createStaticDecl(function (env) {
+          var vaoRef = attributeState.getVAO(vao)
+          if (vaoRef) {
+            return env.link(vaoRef)
+          } else {
+            return 'null'
+          }
+        })
+      } else if (S_VAO in dynamicOptions) {
+        check(!staticOptions.elements && !dynamicOptions.elements, 'cannot specify elements with vao')
+        vaoActive = true
+        var dyn = dynamicOptions[S_VAO]
+        return createDynamicDecl(dyn, function (env, scope) {
+          var vaoRef = env.invoke(scope, dyn)
+          return scope.def(env.shared.vao + '.getVAO(' + vaoRef + ')')
+        })
+      }
+      return null
+    }
+
+    var vao = parseVAO()
+
+    var elementsActive = false
+
     function parseElements () {
       if (S_ELEMENTS in staticOptions) {
+        check(!vaoActive, 'must not specify vao and elements')
+
         var elements = staticOptions[S_ELEMENTS]
+        staticDraw.elements = elements
         if (isBufferArgs(elements)) {
-          elements = elementState.getElements(elementState.create(elements, true))
+          var e = staticDraw.elements = elementState.create(elements, true)
+          elements = elementState.getElements(e)
+          elementsActive = true
         } else if (elements) {
           elements = elementState.getElements(elements)
+          elementsActive = true
           check.command(elements, 'invalid elements', env.commandStr)
         }
+
         var result = createStaticDecl(function (env, scope) {
           if (elements) {
             var result = env.link(elements)
@@ -953,6 +1002,9 @@ module.exports = function reglCore (
         result.value = elements
         return result
       } else if (S_ELEMENTS in dynamicOptions) {
+        check(!vao, 'must not specify vao and elements')
+        elementsActive = true
+
         var dyn = dynamicOptions[S_ELEMENTS]
         return createDynamicDecl(dyn, function (env, scope) {
           var shared = env.shared
@@ -984,15 +1036,20 @@ module.exports = function reglCore (
           return elements
         })
       }
-
       return null
     }
 
     var elements = parseElements()
+    if (elementsActive) {
+      vao = createStaticDecl(function () {
+        return 'null'
+      })
+    }
 
     function parsePrimitive () {
       if (S_PRIMITIVE in staticOptions) {
         var primitive = staticOptions[S_PRIMITIVE]
+        staticDraw.primitive = primitive
         check.commandParameter(primitive, primTypes, 'invalid primitve', env.commandStr)
         return createStaticDecl(function (env, scope) {
           return primTypes[primitive]
@@ -1009,7 +1066,7 @@ module.exports = function reglCore (
           })
           return scope.def(PRIM_TYPES, '[', prim, ']')
         })
-      } else if (elements) {
+      } else if (elementsActive) {
         if (isStatic(elements)) {
           if (elements.value) {
             return createStaticDecl(function (env, scope) {
@@ -1030,6 +1087,14 @@ module.exports = function reglCore (
               return scope.def(elements, '?', elements, '.primType:', GL_TRIANGLES)
             })
         }
+      } else if (vaoActive) {
+        return new Declaration(
+          vao.thisDep,
+          vao.contextDep,
+          vao.propDep,
+          function (env, scope) {
+            return scope.def(env.shared.vao + '.currentVAO?' + env.shared.vao + '.currentVAO.primitive:' + env.shared.draw + '.primitive')
+          })
       }
       return null
     }
@@ -1037,6 +1102,11 @@ module.exports = function reglCore (
     function parseParam (param, isOffset) {
       if (param in staticOptions) {
         var value = staticOptions[param] | 0
+        if (isOffset) {
+          staticDraw.offset = value
+        } else {
+          staticDraw.instances = value
+        }
         check.command(!isOffset || value >= 0, 'invalid ' + param, env.commandStr)
         return createStaticDecl(function (env, scope) {
           if (isOffset) {
@@ -1058,11 +1128,29 @@ module.exports = function reglCore (
           }
           return result
         })
-      } else if (isOffset && elements) {
-        return createStaticDecl(function (env, scope) {
-          env.OFFSET = '0'
-          return 0
-        })
+      } else if (isOffset) {
+        if (vaoActive) {
+          return new Declaration(
+            vao.thisDep,
+            vao.contextDep,
+            vao.propDep,
+            function (env, scope) {
+              return scope.def(env.shared.vao + '.currentVAO?' + env.shared.vao + '.currentVAO.offset:' + env.shared.draw + '.offset')
+            })
+        } else if (elementsActive) {
+          return createStaticDecl(function (env, scope) {
+            env.OFFSET = 0
+            return 0
+          })
+        }
+      } else if (vaoActive) {
+        return new Declaration(
+          vao.thisDep,
+          vao.contextDep,
+          vao.propDep,
+          function (env, scope) {
+            return scope.def(env.shared.vao + '.currentVAO?' + env.shared.vao + '.currentVAO.instances:' + env.shared.draw + '.instances')
+          })
       }
       return null
     }
@@ -1072,6 +1160,7 @@ module.exports = function reglCore (
     function parseVertCount () {
       if (S_COUNT in staticOptions) {
         var count = staticOptions[S_COUNT] | 0
+        staticDraw.count = count
         check.command(
           typeof count === 'number' && count >= 0, 'invalid vertex count', env.commandStr)
         return createStaticDecl(function () {
@@ -1090,7 +1179,7 @@ module.exports = function reglCore (
           })
           return result
         })
-      } else if (elements) {
+      } else if (elementsActive) {
         if (isStatic(elements)) {
           if (elements) {
             if (OFFSET) {
@@ -1142,16 +1231,36 @@ module.exports = function reglCore (
           })
           return variable
         }
+      } else if (vaoActive) {
+        var countVariable = new Declaration(
+          vao.thisDep,
+          vao.contextDep,
+          vao.propDep,
+          function (env, scope) {
+            return scope.def(env.shared.vao, '.currentVAO?', env.shared.vao, '.currentVAO.count:', env.shared.draw + '.count')
+          })
+        return countVariable
       }
       return null
     }
 
+    var primitive = parsePrimitive()
+    var count = parseVertCount()
+    var instances = parseParam(S_INSTANCES, false)
+
     return {
       elements: elements,
-      primitive: parsePrimitive(),
-      count: parseVertCount(),
-      instances: parseParam(S_INSTANCES, false),
-      offset: OFFSET
+      primitive: primitive,
+      count: count,
+      instances: instances,
+      offset: OFFSET,
+      vao: vao,
+
+      vaoActive: vaoActive,
+      elementsActive: elementsActive,
+
+      // static draw props
+      static: staticDraw
     }
   }
 
@@ -1922,27 +2031,6 @@ module.exports = function reglCore (
     return attributeDefs
   }
 
-  function parseVAO (options, env) {
-    var staticOptions = options.static
-    var dynamicOptions = options.dynamic
-    if (S_VAO in staticOptions) {
-      var vao = staticOptions[S_VAO]
-      if (vao !== null && attributeState.getVAO(vao) === null) {
-        vao = attributeState.createVAO(vao)
-      }
-      return createStaticDecl(function (env) {
-        return env.link(attributeState.getVAO(vao))
-      })
-    } else if (S_VAO in dynamicOptions) {
-      var dyn = dynamicOptions[S_VAO]
-      return createDynamicDecl(dyn, function (env, scope) {
-        var vaoRef = env.invoke(scope, dyn)
-        return scope.def(env.shared.vao + '.getVAO(' + vaoRef + ')')
-      })
-    }
-    return null
-  }
-
   function parseContext (context) {
     var staticContext = context.static
     var dynamicContext = context.dynamic
@@ -2033,9 +2121,13 @@ module.exports = function reglCore (
 
     result.profile = parseProfile(options, env)
     result.uniforms = parseUniforms(uniforms, env)
-    result.drawVAO = result.scopeVAO = parseVAO(options, env)
+    result.drawVAO = result.scopeVAO = draw.vao
     // special case: check if we can statically allocate a vertex array object for this program
-    if (!result.drawVAO && shader.program && !attribLocations && extensions.angle_instanced_arrays) {
+    if (!result.drawVAO &&
+      shader.program &&
+      !attribLocations &&
+      extensions.angle_instanced_arrays &&
+      draw.static.elements) {
       var useVAO = true
       var staticBindings = shader.program.attributes.map(function (attr) {
         var binding = attributes.static[attr]
@@ -2043,7 +2135,10 @@ module.exports = function reglCore (
         return binding
       })
       if (useVAO && staticBindings.length > 0) {
-        var vao = attributeState.getVAO(attributeState.createVAO(staticBindings))
+        var vao = attributeState.getVAO(attributeState.createVAO({
+          attributes: staticBindings,
+          elements: draw.static.elements
+        }))
         result.drawVAO = new Declaration(null, null, null, function (env, scope) {
           return env.link(vao)
         })
@@ -2813,18 +2908,26 @@ module.exports = function reglCore (
       var defn = drawOptions.elements
       var ELEMENTS
       var scope = outer
+      if (drawOptions.vaoActive) {
+        // use vao for elements, don't touch element binding state
+        return scope.def(shared.vao + '.currentVAO.elements')
+      }
       if (defn) {
         if ((defn.contextDep && args.contextDynamic) || defn.propDep) {
           scope = inner
         }
         ELEMENTS = defn.append(env, scope)
-      } else {
-        ELEMENTS = scope.def(DRAW_STATE, '.', S_ELEMENTS)
-      }
-      if (ELEMENTS) {
         scope(
           'if(' + ELEMENTS + ')' +
           GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);')
+      } else {
+        ELEMENTS = scope.def()
+        scope('if(', shared.vao, '.currentVAO){',
+          ELEMENTS, '=', shared.vao, '.currentVAO.elements',
+          '}else{',
+          ELEMENTS, '=', DRAW_STATE, '.', S_ELEMENTS, ';',
+          'if(' + ELEMENTS + ')' +
+          GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);}')
       }
       return ELEMENTS
     }
@@ -2908,7 +3011,7 @@ module.exports = function reglCore (
           [PRIMITIVE, OFFSET, COUNT, INSTANCES], ');')
       }
 
-      if (ELEMENTS) {
+      if (ELEMENTS && ELEMENTS !== 'null') {
         if (!elementsStatic) {
           inner('if(', ELEMENTS, '){')
           drawElements()
@@ -2937,7 +3040,7 @@ module.exports = function reglCore (
         inner(GL + '.drawArrays(' + [PRIMITIVE, OFFSET, COUNT] + ');')
       }
 
-      if (ELEMENTS) {
+      if (ELEMENTS && ELEMENTS !== 'null') {
         if (!elementsStatic) {
           inner('if(', ELEMENTS, '){')
           drawElements()

--- a/lib/util/codegen.js
+++ b/lib/util/codegen.js
@@ -166,6 +166,8 @@ module.exports = function createEnvironment () {
       .replace(/;/g, ';\n')
       .replace(/}/g, '}\n')
       .replace(/{/g, '{\n')
+
+    console.log(src)
     var proc = Function.apply(null, linkedNames.concat(src))
     return proc.apply(null, linkedValues)
   }

--- a/lib/util/codegen.js
+++ b/lib/util/codegen.js
@@ -166,8 +166,6 @@ module.exports = function createEnvironment () {
       .replace(/;/g, ';\n')
       .replace(/}/g, '}\n')
       .replace(/{/g, '{\n')
-
-    console.log(src)
     var proc = Function.apply(null, linkedNames.concat(src))
     return proc.apply(null, linkedValues)
   }

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for regl 1.3.1
+// Type definitions for regl 2.0.0
 // Project: regl
 // Definitions by: Stepan Stolyarov <stepan.stolyarov@gmail.com>, David Schneider <github.com/davschne>
 
@@ -217,7 +217,7 @@ declare namespace REGL {
     framebufferCube(options: REGL.FramebufferCubeOptions): REGL.FramebufferCube;
 
     /* Creates a vertex array object */
-    vao(attributes: REGL.AttributeState[]) : REGL.VertexArrayObject;
+    vao(attributes: REGL.AttributeState[] | REGL.VertexArrayOptions) : REGL.VertexArrayObject;
 
     /* Events and listeners */
 
@@ -1072,6 +1072,15 @@ declare namespace REGL {
     "uint8" |
     "uint16" |
     "uint32";
+
+  interface VertexArrayOptions {
+    attributes: AttributeState[];
+    elements?: REGL.Elements | REGL.ElementsOptions | REGL.ElementsData | null;
+    count?:number;
+    offset?:number;
+    primitive?:PrimitiveType;
+    instances?:number;
+  }
 
   interface Texture extends Resource {
     readonly stats: {

--- a/regl.d.ts
+++ b/regl.d.ts
@@ -953,7 +953,7 @@ declare namespace REGL {
   }
 
   interface VertexArrayObject extends REGL.Resource {
-    (attributes:REGL.AttributeState[]) : REGL.VertexArrayObject;
+    (attributes:REGL.AttributeState[] | REGL.VertexArrayOptions) : REGL.VertexArrayObject;
   }
 
   interface Buffer extends REGL.Resource {

--- a/regl.js
+++ b/regl.js
@@ -260,10 +260,10 @@ module.exports = function wrapREGL (args) {
     shaderState.clear()
     framebufferState.clear()
     renderbufferState.clear()
+    attributeState.clear()
     textureState.clear()
     elementState.clear()
     bufferState.clear()
-    attributeState.clear()
 
     if (timer) {
       timer.clear()

--- a/regl.js
+++ b/regl.js
@@ -91,16 +91,18 @@ module.exports = function wrapREGL (args) {
     stats,
     config,
     destroyBuffer)
+  var elementState = wrapElements(gl, extensions, bufferState, stats)
   var attributeState = wrapAttributes(
     gl,
     extensions,
     limits,
     stats,
-    bufferState)
+    bufferState,
+    elementState,
+    drawState)
   function destroyBuffer (buffer) {
     return attributeState.destroyBuffer(buffer)
   }
-  var elementState = wrapElements(gl, extensions, bufferState, stats)
   var shaderState = wrapShaders(gl, stringStore, stats, config)
   var textureState = wrapTextures(
     gl,

--- a/test/vao-elements.js
+++ b/test/vao-elements.js
@@ -41,7 +41,8 @@ function testVAO (regl, t) {
       [ [0, -10], [0, 10] ]
     ],
     elements: null,
-    primitive: 'lines'
+    primitive: 'lines',
+    count: 2
   }
 
   var vaoHorizontalResource = regl.vao(vaoHorizontal)

--- a/test/vao-elements.js
+++ b/test/vao-elements.js
@@ -1,0 +1,216 @@
+var tape = require('tape')
+var createContext = require('./util/create-context')
+var createREGL = require('../regl')
+
+function testVAO (regl, t) {
+  var frag = [
+    'precision highp float;',
+    'void main() {',
+    'gl_FragColor = vec4(1, 1, 1, 1);',
+    '}'
+  ].join('\n')
+
+  var vert = [
+    'precision highp float;',
+    'attribute vec2 position;',
+    'varying vec4 fragColor;',
+    'void main() {',
+    'gl_Position=vec4(position, 0, 1);',
+    'gl_PointSize=1.;',
+    '}'
+  ].join('\n')
+
+  var baseCommand = {
+    frag: frag,
+    vert: vert,
+    attributes: {
+      position: 0
+    },
+    depth: false,
+  }
+
+  var vaoHorizontal = {
+    attributes: [
+        [ [-10, 0], [10, 0] ]
+    ],
+    elements: [ [0, 1] ]
+  }
+
+  var vaoVertical = {
+    attributes: [
+      [ [0, -10], [0, 10] ]
+    ],
+    elements: null,
+    primitive: 'lines'
+  }
+
+  var vaoHorizontalResource = regl.vao(vaoHorizontal)
+  var vaoVerticalResource = regl.vao(vaoVertical)
+
+  var horizontalExpected = [
+    0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0,
+    1, 1, 1, 1, 1,
+    0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0
+  ]
+  var verticalExpected = [
+    0, 0, 1, 0, 0,
+    0, 0, 1, 0, 0,
+    0, 0, 1, 0, 0,
+    0, 0, 1, 0, 0,
+    0, 0, 1, 0, 0
+  ]
+  var crossExpected = [
+    0, 0, 1, 0, 0,
+    0, 0, 1, 0, 0,
+    1, 1, 1, 1, 1,
+    0, 0, 1, 0, 0,
+    0, 0, 1, 0, 0
+  ]
+
+  function check (body, expected, name) {
+    regl.clear({
+      color: [0, 0, 0, 0],
+      depth: 1
+    })
+    body()
+    var actual = regl.read()
+    var actualStr = []
+    var exptectedStr = []
+    for (var i = 0; i < 5; ++i) {
+      for (var j = 0; j < 5; ++j) {
+        var ptr = 5 * i + j
+        exptectedStr.push(expected[ptr])
+        actualStr.push(actual[4 * ptr] ? 1 : 0)
+      }
+      actualStr.push('\n')
+      exptectedStr.push('\n')
+    }
+    t.equals(actualStr.join(''), exptectedStr.join(''), name)
+  }
+
+  var staticScope = regl({
+    vao: vaoVertical
+  })
+
+  var staticResourceScope = regl({
+    vao: vaoVerticalResource
+  })
+
+  var dynamicScope = regl({
+    vao: regl.prop('vao')
+  })
+
+  var drawContext = regl(baseCommand)
+
+  var drawStatic = regl(Object.assign({
+    vao: vaoHorizontal
+  }, baseCommand))
+
+  var drawStaticResource = regl(Object.assign({
+    vao: vaoHorizontalResource
+  }, baseCommand))
+
+  var drawDynamic = regl(Object.assign({
+    vao: regl.prop('vao')
+  }, baseCommand))
+
+  check(function () {
+    drawStatic()
+  }, horizontalExpected, 'draw/static')
+
+  check(function () {
+    drawStaticResource()
+  }, horizontalExpected, 'draw/static-resource')
+
+  check(function () {
+    drawDynamic({
+      vao: vaoVerticalResource
+    })
+  }, verticalExpected, 'draw/prop')
+
+  check(function () {
+    staticScope(function () {
+      drawContext()
+    })
+  }, verticalExpected, 'draw/scope/static')
+
+  check(function () {
+    dynamicScope(
+      { vao: vaoHorizontalResource },
+      function () {
+        drawContext()
+      })
+  }, horizontalExpected, 'draw/scope/dynamic')
+
+  check(function () {
+    drawStatic(1)
+  }, horizontalExpected, 'batch/static')
+
+  check(function () {
+    drawStaticResource(1)
+  }, horizontalExpected, 'batch/static-resource')
+
+  check(function () {
+    drawDynamic([
+      { vao: vaoVerticalResource },
+      { vao: vaoHorizontalResource }
+    ])
+  }, crossExpected, 'batch/prop')
+
+  check(function () {
+    staticScope(function () {
+      drawContext(1)
+    })
+  }, verticalExpected, 'batch/scope/static')
+
+  check(function () {
+    staticResourceScope(function () {
+      drawContext(1)
+    })
+  }, verticalExpected, 'batch/scope/static-resource')
+
+  check(function () {
+    dynamicScope(
+      { vao: vaoHorizontalResource },
+      function () {
+        drawContext(1)
+      })
+  }, horizontalExpected, 'batch/scope/dynamic')
+}
+
+tape('vao - extension', function (t) {
+  var gl = createContext(5, 5)
+  var regl
+  try {
+    regl = createREGL({
+      gl: gl,
+      extensions: [ 'oes_vertex_array_object' ]
+    })
+  } catch (e) {
+    t.pass('extension not supported')
+    createContext.destroy(gl)
+    t.end()
+    return
+  }
+
+  testVAO(regl, t)
+
+  regl.destroy()
+  t.equals(gl.getError(), 0, 'error ok')
+  createContext.destroy(gl)
+  t.end()
+})
+
+tape('vao - emulation', function (t) {
+  var gl = createContext(5, 5)
+  var regl = createREGL(gl)
+
+  testVAO(regl, t)
+
+  regl.destroy()
+  t.equals(gl.getError(), 0, 'error ok')
+  createContext.destroy(gl)
+  t.end()
+})

--- a/test/vao-elements.js
+++ b/test/vao-elements.js
@@ -26,12 +26,12 @@ function testVAO (regl, t) {
     attributes: {
       position: 0
     },
-    depth: false,
+    depth: false
   }
 
   var vaoHorizontal = {
     attributes: [
-        [ [-10, 0], [10, 0] ]
+      [ [-10, 0], [10, 0] ]
     ],
     elements: [ [0, 1] ]
   }


### PR DESCRIPTION
This PR fixes how vertex array object elements work.  The previous interface was based on my own (wrong) understanding of the VAO spec.  I didn't realize that a vertex array object binding included the element buffer state... (dumb)

So the old interfaces didn't reflect the underlying reality and needed to change.  As a result I've made this patch which is the first breaking change in regl.

Most programs should continue to work without modification, but if you are using vertex array objects with elements you will need to move the element state into your VAO definition or else it will break.

All other regl programs should continue to work as usual.