### PR TITLE
Fix canvas resizing behavior

### DIFF
--- a/example/dynamic-resize.js
+++ b/example/dynamic-resize.js
@@ -6,15 +6,21 @@
  */
 
 // Lets inject into a div that is resized dynamically
-const div = document.createElement('div')
-div.style.width = '100%'
-div.style.height = '100vh'
-document.body.appendChild(div)
+const container = document.createElement('div')
+container.style.width = '100%'
+container.style.height = '100vh'
+container.style.border = '10px solid green'
+container.style.margin = '10px'
+document.body.appendChild(container)
 document.body.style.margin = '0'
 
-const regl = require('../regl')({
-  container: div
+// on mouse move make div different size
+window.addEventListener('mousemove', ev => {
+  container.style.width = ev.clientX.toFixed(0) + 'px'
+  container.style.height = ev.clientY.toFixed(0) + 'px'
 })
+
+const regl = require('../regl')({ container })
 
 const drawcmd = regl({
 
@@ -58,9 +64,3 @@ function draw () {
 }
 
 regl.frame(() => draw())
-
-// on mouse move make div different size
-window.addEventListener('mousemove', ev => {
-  div.style.width = ev.clientX.toFixed(0) + 'px'
-  div.style.height = ev.clientY.toFixed(0) + 'px'
-})

--- a/lib/webgl.js
+++ b/lib/webgl.js
@@ -9,7 +9,9 @@ function createCanvas (element, onDone, pixelRatio) {
     margin: 0,
     padding: 0,
     top: 0,
-    left: 0
+    left: 0,
+    width: '100%',
+    height: '100%'
   })
   element.appendChild(canvas)
 
@@ -25,16 +27,12 @@ function createCanvas (element, onDone, pixelRatio) {
     var w = window.innerWidth
     var h = window.innerHeight
     if (element !== document.body) {
-      var bounds = element.getBoundingClientRect()
+      var bounds = canvas.getBoundingClientRect()
       w = bounds.right - bounds.left
       h = bounds.bottom - bounds.top
     }
     canvas.width = pixelRatio * w
     canvas.height = pixelRatio * h
-    extend(canvas.style, {
-      width: w + 'px',
-      height: h + 'px'
-    })
   }
 
   var resizeObserver


### PR DESCRIPTION
Fixes #563 

There was a problem with canvas' `resize()`: canvas is set to a resolution (and size) equal to `getBoundingClientRect` of the parent. This introduces feedback loop effects every time `resize()` is triggered. Instead of bounding box, it should be set to the size of content box.

Solution is as follows: set `width` and `height` of the canvas to `100%` so that it always fills the parent's content box. Update **only** canvas' resolution to be equal to the `getBoundingClientRect` of itself. This way we avoid any feedback loops that can arise, since changing the resolution does not influence canvas' (and in turn, parent's) size.

