### PR TITLE
fix wrong binding when refreshing multiple vaos

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -192,7 +192,7 @@ module.exports = function wrapAttributeState (
     if (ext) {
       ext.bindVertexArrayOES(this.vao)
       this.bindAttrs()
-      state.currentVAO = this
+      state.currentVAO = null
       ext.bindVertexArrayOES(null)
     }
   }

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -193,6 +193,7 @@ module.exports = function wrapAttributeState (
       ext.bindVertexArrayOES(this.vao)
       this.bindAttrs()
       state.currentVAO = this
+      ext.bindVertexArrayOES(null)
     }
   }
 


### PR DESCRIPTION
Found this bug when porting 2.0.1, when refreshing multiple VAO, an elements buffer is binded to a wrong VAO object.

Reset vao status in vao.bindAttrs will fix it.