### PR TITLE
allow to specify elements with VAO, fix #589

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -942,7 +942,6 @@ module.exports = function reglCore (
 
     function parseVAO () {
       if (S_VAO in staticOptions) {
-        check(!staticOptions.elements && !dynamicOptions.elements, 'cannot specify elements with vao')
 
         var vao = staticOptions[S_VAO]
         if (vao !== null && attributeState.getVAO(vao) === null) {
@@ -962,7 +961,6 @@ module.exports = function reglCore (
           }
         })
       } else if (S_VAO in dynamicOptions) {
-        check(!staticOptions.elements && !dynamicOptions.elements, 'cannot specify elements with vao')
         vaoActive = true
         vaoLive = true
         var dyn = dynamicOptions[S_VAO]
@@ -980,7 +978,6 @@ module.exports = function reglCore (
 
     function parseElements () {
       if (S_ELEMENTS in staticOptions) {
-        check(!vaoLive, 'must not specify vao and elements')
 
         var elements = staticOptions[S_ELEMENTS]
         staticDraw.elements = elements
@@ -1006,7 +1003,6 @@ module.exports = function reglCore (
         result.value = elements
         return result
       } else if (S_ELEMENTS in dynamicOptions) {
-        check(!vaoLive, 'must not specify vao and elements')
         elementsActive = true
 
         var dyn = dynamicOptions[S_ELEMENTS]
@@ -1052,11 +1048,6 @@ module.exports = function reglCore (
     }
 
     var elements = parseElements()
-    if (elementsActive) {
-      vao = createStaticDecl(function () {
-        return 'null'
-      })
-    }
 
     function parsePrimitive () {
       if (S_PRIMITIVE in staticOptions) {
@@ -2158,7 +2149,6 @@ module.exports = function reglCore (
       }
     }
     if (attribLocations) {
-      check(!draw.elementsActive, 'can not combine elements and vertex array objects. element binding state must be specified in vertex array object')
       result.useVAO = true
     } else {
       result.attributes = parseAttributes(attributes, env)
@@ -2953,23 +2943,21 @@ module.exports = function reglCore (
         if ((defn.contextDep && args.contextDynamic) || defn.propDep) {
           scope = inner
         }
-        if (drawOptions.vaoActive) {
-          ELEMENTS = defn.append(env, scope)
-        } else {
-          ELEMENTS = defn.append(env, scope)
-          scope(
-            'if(' + ELEMENTS + ')' +
-            GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);')
-        }
+        ELEMENTS = defn.append(env, scope)
+        scope(
+          'if(' + ELEMENTS + ')' +
+          GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);')
+        
       } else {
         ELEMENTS = scope.def()
-        scope('if(', shared.vao, '.currentVAO){',
-          ELEMENTS, '=', env.shared.elements + '.getElements(' + shared.vao, '.currentVAO.elements);',
-          (!extVertexArrays ? 'if(' + ELEMENTS + ')' + GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);' : ''),
-          '}else{',
+        scope(
           ELEMENTS, '=', DRAW_STATE, '.', S_ELEMENTS, ';',
           'if(', ELEMENTS, '){',
-          GL, '.bindBuffer(', GL_ELEMENT_ARRAY_BUFFER, ',', ELEMENTS, '.buffer.buffer);}}')
+          GL, '.bindBuffer(', GL_ELEMENT_ARRAY_BUFFER, ',', ELEMENTS, '.buffer.buffer);}',
+          'else if(', shared.vao, '.currentVAO){',
+          ELEMENTS, '=', env.shared.elements + '.getElements(' + shared.vao, '.currentVAO.elements);',
+          (!extVertexArrays ? 'if(' + ELEMENTS + ')' + GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);' : ''),
+          '}')
       }
       return ELEMENTS
     }

--- a/lib/core.js
+++ b/lib/core.js
@@ -938,18 +938,15 @@ module.exports = function reglCore (
 
     var staticDraw = {}
     var vaoActive = false
-    var vaoLive = false
 
     function parseVAO () {
       if (S_VAO in staticOptions) {
-
         var vao = staticOptions[S_VAO]
         if (vao !== null && attributeState.getVAO(vao) === null) {
           vao = attributeState.createVAO(vao)
         }
 
         vaoActive = true
-        vaoLive = !!vao
         staticDraw.vao = vao
 
         return createStaticDecl(function (env) {
@@ -962,7 +959,6 @@ module.exports = function reglCore (
         })
       } else if (S_VAO in dynamicOptions) {
         vaoActive = true
-        vaoLive = true
         var dyn = dynamicOptions[S_VAO]
         return createDynamicDecl(dyn, function (env, scope) {
           var vaoRef = env.invoke(scope, dyn)
@@ -978,7 +974,6 @@ module.exports = function reglCore (
 
     function parseElements () {
       if (S_ELEMENTS in staticOptions) {
-
         var elements = staticOptions[S_ELEMENTS]
         staticDraw.elements = elements
         if (isBufferArgs(elements)) {
@@ -2944,10 +2939,11 @@ module.exports = function reglCore (
           scope = inner
         }
         ELEMENTS = defn.append(env, scope)
-        scope(
-          'if(' + ELEMENTS + ')' +
-          GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);')
-        
+        if (drawOptions.elementsActive) {
+          scope(
+            'if(' + ELEMENTS + ')' +
+            GL + '.bindBuffer(' + GL_ELEMENT_ARRAY_BUFFER + ',' + ELEMENTS + '.buffer.buffer);')
+        }
       } else {
         ELEMENTS = scope.def()
         scope(


### PR DESCRIPTION
In some cases, users need to have more control on elements with VAO.

* problem as #589 
* when elements needs to be updated frequently (icon fading etc)

Allowing to specify elements along with VAO can fix the above problems, and won't break webgl spec either.