### PR TITLE
Fix depth write failure on shadow cubemap generation

### DIFF
--- a/example/point-light-shadow.js
+++ b/example/point-light-shadow.js
@@ -289,9 +289,10 @@ regl.frame(({ tick }) => {
 
   globalScope(() => {
     drawDepth(6, () => {
+      regl.clear({ depth: 1 })
       drawMeshes()
     })
-
+    regl.clear({ color: [0, 0, 0, 1] })
     drawNormal(() => {
       drawMeshes()
     })


### PR DESCRIPTION
Ensure the depth map is cleared between generating the different faces of the cubemap. If this isnt done, only the first face will have accurate values.