### PR TITLE
Simplify Elements example by using Math.max

### DIFF
--- a/example/elements.js
+++ b/example/elements.js
@@ -10,10 +10,7 @@ regl.clear({
   depth: 1
 })
 
-var lineWidth = 3
-if (lineWidth > regl.limits.lineWidthDims[1]) {
-  lineWidth = regl.limits.lineWidthDims[1]
-}
+var lineWidth = Math.max(3, regl.limits.lineWidthDims[1])
 
 regl({
   frag: `

--- a/example/graph.js
+++ b/example/graph.js
@@ -362,10 +362,7 @@ const renderPoints = regl({
   elements: null
 })
 
-var lineWidth = 2
-if (lineWidth > regl.limits.lineWidthDims[1]) {
-  lineWidth = regl.limits.lineWidthDims[1]
-}
+var lineWidth = Math.max(2, regl.limits.lineWidthDims[1])
 
 const renderEdges = regl({
   vert: `

--- a/example/line-primitives.js
+++ b/example/line-primitives.js
@@ -60,10 +60,7 @@ var globalState = regl({
 })
 
 // make sure to respect system limitations.
-var lineWidth = 3
-if (lineWidth > regl.limits.lineWidthDims[1]) {
-  lineWidth = regl.limits.lineWidthDims[1]
-}
+var lineWidth = Math.max(3, regl.limits.lineWidthDims[1])
 
 // this creates a drawCall that allows you to do draw single line primitive.
 function createDrawCall (props) {


### PR DESCRIPTION
Used Math.max to simplify the lineWidth logic in elements example. The if statement was a little harder to follow, using Math.max makes it easier to figure out what's going on at a glance and reduces code size.