### PR TITLE
Default the keys for dynamic variable binding to the set of keys on the target type

### DIFF
--- a/regl.d.ts
+++ b/regl.d.ts
@@ -136,11 +136,11 @@ declare namespace REGL {
      */
 
     /* Retrieve the property `name` passed when the draw command is executed. */
-    prop<Props extends {}, Key extends keyof Props>(name: Key): DynamicVariable<Props[Key]>;
+    prop<Props extends {}, Key extends keyof Props = keyof Props>(name: Key): DynamicVariable<Props[Key]>;
     /* Retrieve the context property `name` when the draw command is executed. */
-    context<Context extends REGL.DefaultContext, K extends keyof Context>(name: K): DynamicVariable<Context[K]>;
+    context<Context extends REGL.DefaultContext, K extends keyof Context = keyof Context>(name: K): DynamicVariable<Context[K]>;
     /* Retrieve the property `name` of the object in whose context the draw command is executing. */
-    this<This extends {}, Key extends keyof This>(name: Key): DynamicVariable<This[Key]>;
+    this<This extends {}, Key extends keyof This = keyof This>(name: Key): DynamicVariable<This[Key]>;
 
     /* Drawing */
 


### PR DESCRIPTION
By doing this users can specify the type they are using for props, context, this. But without the need to explicitly specify the key-set when they do so.

See also https://github.com/regl-project/regl/issues/602#issuecomment-959813684

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/632)
<!-- Reviewable:end -->
