### PR TITLE
Add missing parameter to attribute opts

### DIFF
--- a/API.md
+++ b/API.md
@@ -755,6 +755,7 @@ Each attribute can have any of the following optional properties,
 | `normalized` | Whether the pointer is normalized                | `false`              |
 | `size`       | The size of the vertex attribute                 | Inferred from shader |
 | `divisor`    | Sets `gl.vertexAttribDivisorANGLE`               | `0` \*               |
+| `type`       | Data type (see [buffer constructor](#buffer-constructor) for options) | Inferred from buffer |
 
 **Notes**
 


### PR DESCRIPTION
Resolves #634 

Attributes get their type from the buffer. However, if you interleave multiple data types into a single buffer, you may wish to specify different types for different attr uses of the same buffer. Regl attributes support `type` in order to accomplish this, though the docs don't mention it.

For a working example, see: https://observablehq.com/d/3c5584380a5a42a4