### PR TITLE
Add OffscreenCanvasRenderingContext2D support to parseImage

### DIFF
--- a/lib/texture.js
+++ b/lib/texture.js
@@ -135,6 +135,7 @@ function objectName (str) {
 var CANVAS_CLASS = objectName('HTMLCanvasElement')
 var OFFSCREENCANVAS_CLASS = objectName('OffscreenCanvas')
 var CONTEXT2D_CLASS = objectName('CanvasRenderingContext2D')
+var OFFSCREEN_CONTEXT2D_CLASS = objectName('OffscreenCanvasRenderingContext2D')
 var BITMAP_CLASS = objectName('ImageBitmap')
 var IMAGE_CLASS = objectName('HTMLImageElement')
 var VIDEO_CLASS = objectName('HTMLVideoElement')
@@ -143,6 +144,7 @@ var PIXEL_CLASSES = Object.keys(dtypes).concat([
   CANVAS_CLASS,
   OFFSCREENCANVAS_CLASS,
   CONTEXT2D_CLASS,
+  OFFSCREEN_CONTEXT2D_CLASS,
   BITMAP_CLASS,
   IMAGE_CLASS,
   VIDEO_CLASS
@@ -212,6 +214,10 @@ function isOffscreenCanvas (object) {
 
 function isContext2D (object) {
   return classString(object) === CONTEXT2D_CLASS
+}
+
+function isOffscreenContext2D (object) {
+  return classString(object) === OFFSCREEN_CONTEXT2D_CLASS
 }
 
 function isBitmap (object) {
@@ -769,7 +775,7 @@ module.exports = function createTextureSet (
       image.format = image.internalformat = CHANNELS_FORMAT[shapeC]
       image.needsFree = true
       transposeData(image, array, strideX, strideY, strideC, data.offset)
-    } else if (isCanvasElement(data) || isOffscreenCanvas(data) || isContext2D(data)) {
+    } else if (isCanvasElement(data) || isOffscreenCanvas(data) || isContext2D(data) || isOffscreenContext2D(data)) {
       if (isCanvasElement(data) || isOffscreenCanvas(data)) {
         image.element = data
       } else {


### PR DESCRIPTION
The `subimage` method currently supports `HTMLCanvasElement`, `CanvasRenderingContext2D`, and `OffscreenCanvas`.

Adding `OffscreenCanvasRenderingContext2D` support makes it more convenient to use in web worker.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/668)
<!-- Reviewable:end -->
