### PR TITLE
Respect buffer's original dimension when updating reglBuffer data

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -225,7 +225,7 @@ module.exports = function wrapBufferState (gl, stats, config, destroyBuffer) {
       var data = null
       var byteLength = 0
       var dtype = 0
-      var dimension = 1
+      var dimension = buffer && buffer.dimension || 1
       if (Array.isArray(options) ||
           isTypedArray(options) ||
           isNDArrayLike(options) ||


### PR DESCRIPTION
Currently, buffer's dimension will be always reset to 1 when calling buffer(array) to update its data.

This default behavior will lead to some incorrect context, e.g. wrong size parameter when calling gl.vertexAttribPointer in REGLVAO.

Respect buffer's original dimension will solve it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regl-project/regl/669)
<!-- Reviewable:end -->
