### PR TITLE
Add Allen Institute ABC Atlas to projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ The following is an incomplete list of projects using regl:
 * [GPU accelerated handwritten digit recognition with regl using Convolutional Neural Networks](https://github.com/Erkaman/regl-cnn)
 * [Bokeh](https://github.com/bokeh/bokeh)
 * [Deepscatter - Zoomable, animated scatterplots in the browser that scales over a billion points](https://github.com/nomic-ai/deepscatter)
+* [Allen Institute ABC Atlas - Brain science data explorer](https://knowledge.brain-map.org/abcatlas)
 
 If you have a project using regl that isn't on this list that you would like to see added, [please send us a pull request!](https://github.com/regl-project/regl/edit/gh-pages/README.md)
 


### PR DESCRIPTION
Hey there, we're using `regl` at the Allen Institute to build a scalable data visualization tool for our scientists and we wanted to add it to the list of projects to show off what `regl` can do!