### PR TITLE
Version 2.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 2.1.1
+
+* A small maintenance release that removes dist files from source control ([#676](https://github.com/regl-project/regl/pull/676)), upgrades headless-gl for dev ([#675](https://github.com/regl-project/regl/pull/675)), and adds missing TypeScript declarations ([#674](https://github.com/regl-project/regl/pull/674)). It should contain no changes to runtime execution.
+
 ## 1.6.1
 
 * Browsers select their own, perhaps inconsistent, default for the `premultipledAlpha` context creation attribute. Regl enforces consistency by filling in unspecified values but since 1.4.0 has enforced `false` if unspecified, which seems to be nonstandard and in the minority. For improved backward compatibility, this PR sets `premultipledAlpha: true` when not explicitly specified. ([#566](https://github.com/regl-project/regl/pull/566), [#567](https://github.com/regl-project/regl/pull/567))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "regl",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "regl",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "angle-normals": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "regl is a fast functional WebGL framework.",
   "main": "dist/regl.js",
   "types": "dist/regl.d.ts",


### PR DESCRIPTION
This is just a tiny patch release with no that tries to dust off the cobwebs and keep the wheels turning a bit longer by making maintenance perhaps a bit easier. It contains #676, #675, and #674.

Side note: I tried bulk-updating all of the deps, but there was nothing to be gained from it. Except about 1 additional kb to the minified bundle size for random reasons that only google closure knows.